### PR TITLE
feat(US-02 to US-09): full ingestion pipeline implementation

### DIFF
--- a/Backend/BackendAPI/BackendAPI.csproj
+++ b/Backend/BackendAPI/BackendAPI.csproj
@@ -10,9 +10,13 @@
     <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
     <PackageReference Include="Dapper" Version="2.1.72" />
     <PackageReference Include="Google.Apis.Auth" Version="1.73.0" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.14" />
+    <PackageReference Include="Hangfire.Core" Version="1.8.14" />
+    <PackageReference Include="Hangfire.SqlServer" Version="1.8.14" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
+    <PackageReference Include="System.ServiceModel.Syndication" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Backend/BackendAPI/Interfaces/IIngestionService.cs
+++ b/Backend/BackendAPI/Interfaces/IIngestionService.cs
@@ -1,0 +1,20 @@
+using BackendAPI.Models;
+
+namespace BackendAPI.Interfaces
+{
+    /// <summary>Contract for a single ingestion source (RSS, YouTube, GNews …).</summary>
+    public interface IRssIngestionService
+    {
+        Task<IEnumerable<TrendingTopic>> FetchAsync();
+    }
+
+    public interface IYouTubeIngestionService
+    {
+        Task<IEnumerable<TrendingTopic>> FetchAsync();
+    }
+
+    public interface IGNewsIngestionService
+    {
+        Task<IEnumerable<TrendingTopic>> FetchAsync();
+    }
+}

--- a/Backend/BackendAPI/Interfaces/IPollGenerationService.cs
+++ b/Backend/BackendAPI/Interfaces/IPollGenerationService.cs
@@ -1,0 +1,20 @@
+using BackendAPI.Models;
+
+namespace BackendAPI.Interfaces
+{
+    public interface IPollGenerationService
+    {
+        /// <summary>
+        /// Calls the Llama/Mistral VM endpoint to generate a poll from a trending topic.
+        /// Returns null when the model cannot produce a valid poll.
+        /// </summary>
+        Task<GeneratedPoll?> GenerateAsync(TrendingTopic topic);
+    }
+
+    public class GeneratedPoll
+    {
+        public string Question { get; set; } = string.Empty;
+        public List<string> Options { get; set; } = new();
+        public string Category { get; set; } = "General";
+    }
+}

--- a/Backend/BackendAPI/Jobs/IngestionJob.cs
+++ b/Backend/BackendAPI/Jobs/IngestionJob.cs
@@ -1,0 +1,59 @@
+using BackendAPI.Interfaces;
+
+namespace BackendAPI.Jobs
+{
+    /// <summary>
+    /// US-06 — Hangfire recurring job that orchestrates all ingestion sources.
+    /// Scheduled: every 30 minutes (cron: "*/30 * * * *").
+    /// Runs RSS, YouTube, and GNews in parallel, merges results, deduplicates, saves to TrendingTopics.
+    /// </summary>
+    public class IngestionJob
+    {
+        private readonly IRssIngestionService     _rss;
+        private readonly IYouTubeIngestionService _youtube;
+        private readonly IGNewsIngestionService   _gnews;
+        private readonly ITrendingTopicRepository _repo;
+        private readonly ILogger<IngestionJob>    _logger;
+
+        public IngestionJob(
+            IRssIngestionService rss,
+            IYouTubeIngestionService youtube,
+            IGNewsIngestionService gnews,
+            ITrendingTopicRepository repo,
+            ILogger<IngestionJob> logger)
+        {
+            _rss     = rss;
+            _youtube = youtube;
+            _gnews   = gnews;
+            _repo    = repo;
+            _logger  = logger;
+        }
+
+        public async Task RunAsync()
+        {
+            _logger.LogInformation("[IngestionJob] Starting ingestion run at {Time}", DateTime.UtcNow);
+
+            // Fetch all sources in parallel
+            var tasks = new[]
+            {
+                _rss.FetchAsync(),
+                _youtube.FetchAsync(),
+                _gnews.FetchAsync()
+            };
+
+            var results = await Task.WhenAll(tasks);
+
+            var allTopics = results.SelectMany(r => r).ToList();
+            _logger.LogInformation("[IngestionJob] Total topics fetched: {Count}", allTopics.Count);
+
+            if (allTopics.Count == 0)
+            {
+                _logger.LogWarning("[IngestionJob] No topics fetched — nothing to save");
+                return;
+            }
+
+            await _repo.SaveBatchAsync(allTopics);
+            _logger.LogInformation("[IngestionJob] Saved batch to TrendingTopics (dedup applied)");
+        }
+    }
+}

--- a/Backend/BackendAPI/Jobs/PollGenerationJob.cs
+++ b/Backend/BackendAPI/Jobs/PollGenerationJob.cs
@@ -1,0 +1,101 @@
+using BackendAPI.Interfaces;
+using BackendAPI.Models;
+
+namespace BackendAPI.Jobs
+{
+    /// <summary>
+    /// US-08 — Hangfire recurring job that reads unprocessed TrendingTopics,
+    /// calls the poll-generation VM for each, persists the resulting poll,
+    /// and marks the topic as processed.
+    ///
+    /// Scheduled: every 35 minutes offset by 5 min (cron: "5/35 * * * *")
+    /// so ingestion always runs first.
+    /// </summary>
+    public class PollGenerationJob
+    {
+        private readonly ITrendingTopicRepository _topicRepo;
+        private readonly IPollsRepository         _pollsRepo;
+        private readonly IPollGenerationService   _generator;
+        private readonly ILogger<PollGenerationJob> _logger;
+
+        // Polls expire 48 hours after creation by default
+        private static readonly TimeSpan DefaultExpiry = TimeSpan.FromHours(48);
+
+        public PollGenerationJob(
+            ITrendingTopicRepository topicRepo,
+            IPollsRepository pollsRepo,
+            IPollGenerationService generator,
+            ILogger<PollGenerationJob> logger)
+        {
+            _topicRepo = topicRepo;
+            _pollsRepo = pollsRepo;
+            _generator = generator;
+            _logger    = logger;
+        }
+
+        public async Task RunAsync()
+        {
+            _logger.LogInformation("[PollGenerationJob] Starting at {Time}", DateTime.UtcNow);
+
+            var topics = (await _topicRepo.GetUnprocessedAsync(maxCount: 20)).ToList();
+
+            if (topics.Count == 0)
+            {
+                _logger.LogInformation("[PollGenerationJob] No unprocessed topics — nothing to do");
+                return;
+            }
+
+            _logger.LogInformation("[PollGenerationJob] Processing {Count} topics", topics.Count);
+
+            int created = 0, skipped = 0;
+
+            foreach (var topic in topics)
+            {
+                var generated = await _generator.GenerateAsync(topic);
+
+                if (generated == null)
+                {
+                    _logger.LogWarning("[PollGenerationJob] Skipping topic {Id} — generation returned null", topic.Id);
+                    skipped++;
+                    // Still mark as processed so we don't retry indefinitely
+                    await _topicRepo.MarkProcessedAsync(topic.Id);
+                    continue;
+                }
+
+                try
+                {
+                    var request = new CreatePollRequest
+                    {
+                        Question     = generated.Question,
+                        Description  = topic.Summary,
+                        Category     = generated.Category,
+                        ExpiresAt    = DateTime.UtcNow.Add(DefaultExpiry),
+                        Options      = generated.Options,
+                        SourceType   = topic.SourceType,
+                        SourceUrl    = topic.SourceUrl,
+                        ThumbnailUrl = topic.ThumbnailUrl,
+                        IsAIGenerated = true
+                    };
+
+                    var pollId = await _pollsRepo.CreateAsync(request);
+                    await _topicRepo.MarkProcessedAsync(topic.Id);
+
+                    _logger.LogInformation(
+                        "[PollGenerationJob] Created poll {PollId} from topic {TopicId}: '{Question}'",
+                        pollId, topic.Id, generated.Question);
+
+                    created++;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex,
+                        "[PollGenerationJob] Failed to save poll for topic {TopicId}", topic.Id);
+                }
+            }
+
+            _logger.LogInformation(
+                "[PollGenerationJob] Done — created: {Created}, skipped: {Skipped}",
+                created, skipped);
+        }
+    }
+}

--- a/Backend/BackendAPI/Program.cs
+++ b/Backend/BackendAPI/Program.cs
@@ -1,7 +1,11 @@
 using BackendAPI.Data;
 using BackendAPI.Interfaces;
-using BackendAPI.Repository;
+using BackendAPI.Jobs;
 using BackendAPI.Models;
+using BackendAPI.Repository;
+using BackendAPI.Services;
+using Hangfire;
+using Hangfire.SqlServer;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
@@ -41,12 +45,44 @@ builder.Services.AddAuthorization();
 builder.Services.AddSingleton<DapperContext>();
 
 // ── Repositories ──────────────────────────────────────────────────────────
-builder.Services.AddScoped<IAuthRepository,           AuthRepository>();
-builder.Services.AddScoped<IPollsRepository,          PollsRepository>();
-builder.Services.AddScoped<IVotesRepository,          VotesRepository>();
-builder.Services.AddScoped<IUsersRepository,          UsersRepository>();
-builder.Services.AddScoped<IDashboardRepository,      DashboardRepository>();
-builder.Services.AddScoped<ITrendingTopicRepository,  TrendingTopicRepository>();
+builder.Services.AddScoped<IAuthRepository,          AuthRepository>();
+builder.Services.AddScoped<IPollsRepository,         PollsRepository>();
+builder.Services.AddScoped<IVotesRepository,         VotesRepository>();
+builder.Services.AddScoped<IUsersRepository,         UsersRepository>();
+builder.Services.AddScoped<IDashboardRepository,     DashboardRepository>();
+builder.Services.AddScoped<ITrendingTopicRepository, TrendingTopicRepository>();
+
+// ── Ingestion Services (US-03, US-04, US-05) ──────────────────────────────
+builder.Services.AddHttpClient();
+builder.Services.AddScoped<IRssIngestionService,     RssIngestionService>();
+builder.Services.AddScoped<IYouTubeIngestionService, YouTubeIngestionService>();
+builder.Services.AddScoped<IGNewsIngestionService,   GNewsIngestionService>();
+
+// ── Poll Generation Service (US-07) ──────────────────────────────────────
+builder.Services.AddScoped<IPollGenerationService,   PollGenerationService>();
+
+// ── Hangfire Jobs — must be registered in DI so Hangfire can resolve them ─
+builder.Services.AddScoped<IngestionJob>();
+builder.Services.AddScoped<PollGenerationJob>();
+
+// ── Hangfire (US-02) ──────────────────────────────────────────────────────
+var hangfireConn = builder.Configuration.GetConnectionString("DefaultConnection")!;
+builder.Services.AddHangfire(config => config
+    .SetDataCompatibilityLevel(CompatibilityLevel.Version_180)
+    .UseSimpleAssemblyNameTypeSerializer()
+    .UseRecommendedSerializerSettings()
+    .UseSqlServerStorage(hangfireConn, new SqlServerStorageOptions
+    {
+        CommandBatchMaxTimeout     = TimeSpan.FromMinutes(5),
+        SlidingInvisibilityTimeout = TimeSpan.FromMinutes(5),
+        QueuePollInterval          = TimeSpan.Zero,
+        PrepareSchemaIfNecessary   = true   // auto-creates Hangfire schema tables
+    }));
+
+builder.Services.AddHangfireServer(options =>
+{
+    options.WorkerCount = 2;   // light footprint on App Service free/basic tier
+});
 
 // ── CORS — allow Next.js frontend ─────────────────────────────────────────
 builder.Services.AddCors(options =>
@@ -67,6 +103,9 @@ if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
     app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "Pollify API v1"));
+
+    // Hangfire Dashboard — dev only (no auth); US-11 adds Basic Auth for prod
+    app.UseHangfireDashboard("/hangfire");
 }
 
 app.UseHttpsRedirection();
@@ -74,5 +113,25 @@ app.UseCors("FrontendPolicy");
 app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();
+
+// ── Register recurring jobs (US-06, US-08) ───────────────────────────────
+// Jobs are registered after the app is built so IRecurringJobManager is available.
+using (var scope = app.Services.CreateScope())
+{
+    var recurringJobs = scope.ServiceProvider.GetRequiredService<IRecurringJobManager>();
+
+    // US-06: Ingest trending topics every 30 minutes
+    recurringJobs.AddOrUpdate<IngestionJob>(
+        "ingest-trending-topics",
+        job => job.RunAsync(),
+        "*/30 * * * *");
+
+    // US-08: Generate polls from unprocessed topics every 35 minutes
+    // (offset by 5 min so ingestion always runs first)
+    recurringJobs.AddOrUpdate<PollGenerationJob>(
+        "generate-polls-from-topics",
+        job => job.RunAsync(),
+        "5/35 * * * *");
+}
 
 app.Run();

--- a/Backend/BackendAPI/Repository/PollsRepository.cs
+++ b/Backend/BackendAPI/Repository/PollsRepository.cs
@@ -71,12 +71,14 @@ namespace BackendAPI.Repository
 
             var pollDict = new Dictionary<long, Poll>();
 
+            // US-09: order by TotalVotes DESC directly — no longer requires IsTrending = 1
+            // IsTrending flag is still refreshed by a Hangfire job but is not a blocker.
             await conn.QueryAsync<Poll, PollOption, Poll>(
                 @"SELECT TOP (@Count) p.*, o.*
                   FROM Polls p
                   LEFT JOIN PollOptions o ON o.PollId = p.Id
-                  WHERE p.IsActive = 1 AND p.IsTrending = 1
-                  ORDER BY p.TotalVotes DESC",
+                  WHERE p.IsActive = 1
+                  ORDER BY p.TotalVotes DESC, p.CreatedAt DESC",
                 (poll, option) =>
                 {
                     if (!pollDict.TryGetValue(poll.Id, out var existing))

--- a/Backend/BackendAPI/Services/GNewsIngestionService.cs
+++ b/Backend/BackendAPI/Services/GNewsIngestionService.cs
@@ -1,0 +1,91 @@
+using BackendAPI.Interfaces;
+using BackendAPI.Models;
+using System.Text.Json;
+
+namespace BackendAPI.Services
+{
+    /// <summary>
+    /// US-05 — Fetches top Indian news headlines via GNews API (free tier: 100 req/day).
+    /// Config key: GNews:ApiKey  (set in appsettings.json or Azure App Settings)
+    /// Docs: https://gnews.io/docs/v4
+    /// </summary>
+    public class GNewsIngestionService : IGNewsIngestionService
+    {
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly IConfiguration _config;
+        private readonly ILogger<GNewsIngestionService> _logger;
+
+        // Fetch top 10 headlines in English for India
+        private const string BaseUrl =
+            "https://gnews.io/api/v4/top-headlines" +
+            "?country=in&lang=en&max=10&token={0}";
+
+        public GNewsIngestionService(
+            IHttpClientFactory httpClientFactory,
+            IConfiguration config,
+            ILogger<GNewsIngestionService> logger)
+        {
+            _httpClientFactory = httpClientFactory;
+            _config            = config;
+            _logger            = logger;
+        }
+
+        public async Task<IEnumerable<TrendingTopic>> FetchAsync()
+        {
+            var apiKey = _config["GNews:ApiKey"];
+            if (string.IsNullOrWhiteSpace(apiKey))
+            {
+                _logger.LogWarning("GNews:ApiKey not configured — skipping GNews ingestion");
+                return Enumerable.Empty<TrendingTopic>();
+            }
+
+            try
+            {
+                var client = _httpClientFactory.CreateClient();
+                var url    = string.Format(BaseUrl, apiKey);
+
+                using var response = await client.GetAsync(url);
+                response.EnsureSuccessStatusCode();
+
+                var json = await response.Content.ReadAsStringAsync();
+                return ParseResponse(json);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "GNews ingestion failed");
+                return Enumerable.Empty<TrendingTopic>();
+            }
+        }
+
+        private static List<TrendingTopic> ParseResponse(string json)
+        {
+            var topics = new List<TrendingTopic>();
+
+            using var doc = JsonDocument.Parse(json);
+            if (!doc.RootElement.TryGetProperty("articles", out var articles)) return topics;
+
+            foreach (var article in articles.EnumerateArray())
+            {
+                var title = article.TryGetProperty("title", out var t) ? t.GetString()?.Trim() ?? "" : "";
+                var desc  = article.TryGetProperty("description", out var d) ? d.GetString() ?? "" : "";
+                var url   = article.TryGetProperty("url", out var u) ? u.GetString() ?? "" : "";
+                var img   = article.TryGetProperty("image", out var i) ? i.GetString() : null;
+
+                if (desc.Length > 500) desc = desc[..500];
+                if (string.IsNullOrWhiteSpace(title)) continue;
+
+                topics.Add(new TrendingTopic
+                {
+                    Title        = title,
+                    Summary      = desc,
+                    SourceType   = "gnews",
+                    SourceUrl    = url,
+                    ThumbnailUrl = img,
+                    Category     = "General"
+                });
+            }
+
+            return topics;
+        }
+    }
+}

--- a/Backend/BackendAPI/Services/PollGenerationService.cs
+++ b/Backend/BackendAPI/Services/PollGenerationService.cs
@@ -1,0 +1,132 @@
+using BackendAPI.Interfaces;
+using BackendAPI.Models;
+using System.Text;
+using System.Text.Json;
+
+namespace BackendAPI.Services
+{
+    /// <summary>
+    /// US-07 — Calls the deployed Llama/Mistral VM endpoint to generate a poll
+    /// from a TrendingTopic.
+    ///
+    /// Config keys (appsettings.json / Azure App Settings):
+    ///   PollGen:BaseUrl  — e.g. http://your-vm-ip:8000   (placeholder until real URL is provided)
+    ///   PollGen:ApiKey   — optional bearer token (leave empty if VM has no auth)
+    ///
+    /// Expected request  POST /generate
+    ///   { "title": "...", "summary": "...", "category": "..." }
+    ///
+    /// Expected response (model must return valid JSON):
+    ///   {
+    ///     "question": "...",
+    ///     "options":  ["...", "...", "...", "..."],
+    ///     "category": "..."
+    ///   }
+    /// </summary>
+    public class PollGenerationService : IPollGenerationService
+    {
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly IConfiguration _config;
+        private readonly ILogger<PollGenerationService> _logger;
+
+        public PollGenerationService(
+            IHttpClientFactory httpClientFactory,
+            IConfiguration config,
+            ILogger<PollGenerationService> logger)
+        {
+            _httpClientFactory = httpClientFactory;
+            _config            = config;
+            _logger            = logger;
+        }
+
+        public async Task<GeneratedPoll?> GenerateAsync(TrendingTopic topic)
+        {
+            var baseUrl = _config["PollGen:BaseUrl"];
+            if (string.IsNullOrWhiteSpace(baseUrl))
+            {
+                _logger.LogWarning("PollGen:BaseUrl not configured — skipping poll generation");
+                return null;
+            }
+
+            try
+            {
+                var client = _httpClientFactory.CreateClient();
+
+                // Attach bearer token if configured
+                var apiKey = _config["PollGen:ApiKey"];
+                if (!string.IsNullOrWhiteSpace(apiKey))
+                    client.DefaultRequestHeaders.Authorization =
+                        new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", apiKey);
+
+                var payload = new
+                {
+                    title    = topic.Title,
+                    summary  = topic.Summary,
+                    category = topic.Category
+                };
+
+                var content = new StringContent(
+                    JsonSerializer.Serialize(payload),
+                    Encoding.UTF8,
+                    "application/json");
+
+                using var response = await client.PostAsync($"{baseUrl.TrimEnd('/')}/generate", content);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    _logger.LogWarning(
+                        "PollGen VM returned {Status} for topic '{Title}'",
+                        (int)response.StatusCode, topic.Title);
+                    return null;
+                }
+
+                var json = await response.Content.ReadAsStringAsync();
+                return ParseResponse(json, topic.Category);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "PollGen failed for topic '{Title}'", topic.Title);
+                return null;
+            }
+        }
+
+        private static GeneratedPoll? ParseResponse(string json, string fallbackCategory)
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(json);
+                var root = doc.RootElement;
+
+                var question = root.TryGetProperty("question", out var q) ? q.GetString() : null;
+                var category = root.TryGetProperty("category", out var c) ? c.GetString() : fallbackCategory;
+
+                if (string.IsNullOrWhiteSpace(question)) return null;
+
+                var options = new List<string>();
+                if (root.TryGetProperty("options", out var opts))
+                {
+                    foreach (var opt in opts.EnumerateArray())
+                    {
+                        var text = opt.GetString()?.Trim();
+                        if (!string.IsNullOrWhiteSpace(text))
+                            options.Add(text);
+                    }
+                }
+
+                // Need at least 2 options to form a valid poll
+                if (options.Count < 2) return null;
+
+                return new GeneratedPoll
+                {
+                    Question = question!,
+                    Options  = options,
+                    Category = category ?? fallbackCategory
+                };
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/Backend/BackendAPI/Services/RssIngestionService.cs
+++ b/Backend/BackendAPI/Services/RssIngestionService.cs
@@ -1,0 +1,122 @@
+using BackendAPI.Interfaces;
+using BackendAPI.Models;
+using System.ServiceModel.Syndication;
+using System.Xml;
+
+namespace BackendAPI.Services
+{
+    /// <summary>
+    /// US-03 — Fetches trending topics from RSS feeds.
+    /// Sources: Google News (India), The Hindu, Times of India, NDTV, BBC, Reuters, Indian Express.
+    /// Uses only built-in .NET System.ServiceModel.Syndication — no extra NuGet required.
+    /// </summary>
+    public class RssIngestionService : IRssIngestionService
+    {
+        private readonly ILogger<RssIngestionService> _logger;
+
+        // Source → (feed URL, category)
+        private static readonly (string Name, string Url, string Category)[] Feeds =
+        {
+            ("Google News India",   "https://news.google.com/rss?hl=en-IN&gl=IN&ceid=IN:en",             "General"),
+            ("The Hindu",           "https://www.thehindu.com/news/national/?service=rss",               "India"),
+            ("Times of India",      "https://timesofindia.indiatimes.com/rssfeedstopstories.cms",        "India"),
+            ("NDTV Top Stories",    "https://feeds.feedburner.com/ndtvnews-top-stories",                 "India"),
+            ("BBC World",           "https://feeds.bbci.co.uk/news/world/rss.xml",                      "World"),
+            ("Reuters Top News",    "https://feeds.reuters.com/reuters/topNews",                         "World"),
+            ("Indian Express",      "https://indianexpress.com/feed/",                                   "India"),
+        };
+
+        public RssIngestionService(ILogger<RssIngestionService> logger)
+        {
+            _logger = logger;
+        }
+
+        public async Task<IEnumerable<TrendingTopic>> FetchAsync()
+        {
+            var results = new List<TrendingTopic>();
+
+            foreach (var (name, url, category) in Feeds)
+            {
+                try
+                {
+                    var items = await FetchFeedAsync(url, name, category);
+                    results.AddRange(items);
+                    _logger.LogInformation("RSS [{Source}]: fetched {Count} items", name, items.Count);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "RSS [{Source}]: failed to fetch", name);
+                }
+            }
+
+            return results;
+        }
+
+        private static Task<List<TrendingTopic>> FetchFeedAsync(
+            string url, string sourceName, string category)
+        {
+            return Task.Run(() =>
+            {
+                var topics = new List<TrendingTopic>();
+
+                var settings = new XmlReaderSettings
+                {
+                    DtdProcessing = DtdProcessing.Ignore,
+                    MaxCharactersFromEntities = 1024
+                };
+
+                using var reader = XmlReader.Create(url, settings);
+                var feed = SyndicationFeed.Load(reader);
+
+                foreach (var item in feed.Items.Take(10))   // max 10 per feed
+                {
+                    var link = item.Links.FirstOrDefault()?.Uri?.ToString() ?? "";
+                    var summary = item.Summary?.Text
+                        ?? (item.Content as TextSyndicationContent)?.Text
+                        ?? "";
+
+                    // Strip basic HTML tags from summaries
+                    summary = System.Text.RegularExpressions.Regex
+                        .Replace(summary, "<[^>]+>", "")
+                        .Trim();
+                    if (summary.Length > 500) summary = summary[..500];
+
+                    var title = item.Title?.Text?.Trim() ?? "";
+                    if (string.IsNullOrWhiteSpace(title)) continue;
+
+                    // Try to extract a thumbnail from media:thumbnail or enclosure
+                    string? thumbnail = null;
+                    if (item.ElementExtensions != null)
+                    {
+                        foreach (var ext in item.ElementExtensions)
+                        {
+                            if (ext.OuterName.Equals("thumbnail", StringComparison.OrdinalIgnoreCase)
+                                || ext.OuterName.Equals("content", StringComparison.OrdinalIgnoreCase))
+                            {
+                                try
+                                {
+                                    var xElem = ext.GetObject<System.Xml.Linq.XElement>();
+                                    thumbnail = xElem.Attribute("url")?.Value;
+                                    if (thumbnail != null) break;
+                                }
+                                catch { /* ignore malformed extensions */ }
+                            }
+                        }
+                    }
+
+                    topics.Add(new TrendingTopic
+                    {
+                        Title        = title,
+                        Summary      = summary,
+                        SourceType   = "rss",
+                        SourceUrl    = link,
+                        ThumbnailUrl = thumbnail,
+                        Category     = category
+                    });
+                }
+
+                return topics;
+            });
+        }
+    }
+}

--- a/Backend/BackendAPI/Services/YouTubeIngestionService.cs
+++ b/Backend/BackendAPI/Services/YouTubeIngestionService.cs
@@ -1,0 +1,113 @@
+using BackendAPI.Interfaces;
+using BackendAPI.Models;
+using System.Text.Json;
+
+namespace BackendAPI.Services
+{
+    /// <summary>
+    /// US-04 — Fetches trending YouTube videos (India) via YouTube Data API v3.
+    /// Free tier: 10,000 units/day; one videos.list call costs 1 unit.
+    /// Config key: YouTube:ApiKey  (set in appsettings.json or Azure App Settings)
+    /// </summary>
+    public class YouTubeIngestionService : IYouTubeIngestionService
+    {
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly IConfiguration _config;
+        private readonly ILogger<YouTubeIngestionService> _logger;
+
+        // YouTube Data API v3 — most popular videos in India (videoCategoryId=25 = News & Politics)
+        private const string BaseUrl =
+            "https://www.googleapis.com/youtube/v3/videos" +
+            "?part=snippet,statistics" +
+            "&chart=mostPopular" +
+            "&regionCode=IN" +
+            "&videoCategoryId=25" +
+            "&maxResults=10" +
+            "&key={0}";
+
+        public YouTubeIngestionService(
+            IHttpClientFactory httpClientFactory,
+            IConfiguration config,
+            ILogger<YouTubeIngestionService> logger)
+        {
+            _httpClientFactory = httpClientFactory;
+            _config            = config;
+            _logger            = logger;
+        }
+
+        public async Task<IEnumerable<TrendingTopic>> FetchAsync()
+        {
+            var apiKey = _config["YouTube:ApiKey"];
+            if (string.IsNullOrWhiteSpace(apiKey))
+            {
+                _logger.LogWarning("YouTube:ApiKey not configured — skipping YouTube ingestion");
+                return Enumerable.Empty<TrendingTopic>();
+            }
+
+            try
+            {
+                var client = _httpClientFactory.CreateClient();
+                var url    = string.Format(BaseUrl, apiKey);
+
+                using var response = await client.GetAsync(url);
+                response.EnsureSuccessStatusCode();
+
+                var json = await response.Content.ReadAsStringAsync();
+                return ParseResponse(json);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "YouTube ingestion failed");
+                return Enumerable.Empty<TrendingTopic>();
+            }
+        }
+
+        private static List<TrendingTopic> ParseResponse(string json)
+        {
+            var topics = new List<TrendingTopic>();
+
+            using var doc = JsonDocument.Parse(json);
+            if (!doc.RootElement.TryGetProperty("items", out var items)) return topics;
+
+            foreach (var item in items.EnumerateArray())
+            {
+                var videoId  = item.GetProperty("id").GetString() ?? "";
+                var snippet  = item.GetProperty("snippet");
+                var title    = snippet.GetProperty("title").GetString()?.Trim() ?? "";
+                var desc     = snippet.TryGetProperty("description", out var d) ? d.GetString() ?? "" : "";
+                var category = "Entertainment";
+
+                if (desc.Length > 400) desc = desc[..400];
+
+                // Thumbnail: prefer maxres, then high, then default
+                string? thumbnail = null;
+                if (snippet.TryGetProperty("thumbnails", out var thumbs))
+                {
+                    foreach (var quality in new[] { "maxres", "high", "medium", "default" })
+                    {
+                        if (thumbs.TryGetProperty(quality, out var t)
+                            && t.TryGetProperty("url", out var tu))
+                        {
+                            thumbnail = tu.GetString();
+                            break;
+                        }
+                    }
+                }
+
+                if (string.IsNullOrWhiteSpace(title)) continue;
+
+                topics.Add(new TrendingTopic
+                {
+                    Title        = title,
+                    Summary      = desc,
+                    SourceType   = "youtube",
+                    SourceUrl    = $"https://www.youtube.com/watch?v={videoId}",
+                    ThumbnailUrl = thumbnail,
+                    Category     = category
+                });
+            }
+
+            return topics;
+        }
+    }
+}

--- a/Backend/BackendAPI/appsettings.json
+++ b/Backend/BackendAPI/appsettings.json
@@ -11,10 +11,21 @@
   "Google": {
     "ClientId": "CHANGE_ME_your_google_oauth_client_id.apps.googleusercontent.com"
   },
+  "YouTube": {
+    "ApiKey": ""
+  },
+  "GNews": {
+    "ApiKey": ""
+  },
+  "PollGen": {
+    "BaseUrl": "",
+    "ApiKey": ""
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Hangfire": "Information"
     }
   },
   "AllowedHosts": "*"


### PR DESCRIPTION
US-01 (DB Migration)
- SQL: ALTER Polls adds SourceType, SourceUrl, ThumbnailUrl, IsAIGenerated
- SQL: CREATE TrendingTopics staging table with dedup index
- Poll + TrendingTopic models updated; CreatePollRequest includes source fields
- ITrendingTopicRepository + TrendingTopicRepository (SaveBatch, GetUnprocessed, MarkProcessed)

US-02 (Hangfire Setup)
- Packages: Hangfire.Core, Hangfire.AspNetCore, Hangfire.SqlServer 1.8.14
- SqlServer storage with PrepareSchemaIfNecessary (auto-creates Hangfire tables)
- HangfireServer with 2 workers; Dashboard on /hangfire in dev

US-03 (RSS Ingestion)
- RssIngestionService: 7 feeds (Google News IN, The Hindu, TOI, NDTV, BBC, Reuters, Indian Express)
- Uses System.ServiceModel.Syndication; thumbnail extraction from media extensions

US-04 (YouTube Ingestion)
- YouTubeIngestionService: Data API v3, India trending, News & Politics category
- Skips gracefully when YouTube:ApiKey not configured

US-05 (GNews Ingestion)
- GNewsIngestionService: top-headlines India, free tier (100 req/day)
- Skips gracefully when GNews:ApiKey not configured

US-06 (Ingestion Job)
- IngestionJob: orchestrates RSS + YouTube + GNews in parallel, saves deduped batch

US-07 (Poll Generation Service)
- PollGenerationService: POSTs to PollGen:BaseUrl/generate (Llama/Mistral VM placeholder)
- Parses JSON response {question, options[], category}; returns null on failure

US-08 (Poll Generation Job)
- PollGenerationJob: reads up to 20 unprocessed topics, calls generator, saves polls
- Marks topics processed even on generation failure to avoid retry loops

US-09 (Fix Trending Query)
- GetTrendingAsync now orders by TotalVotes DESC, CreatedAt DESC
- No longer requires IsTrending = 1 (polls always visible)

Recurring schedule (Program.cs):
- ingest-trending-topics    every 30 min
- generate-polls-from-topics every 35 min (offset +5)