### PR TITLE
feat(US-11): protect Hangfire dashboard with Basic Auth in production

### DIFF
--- a/Backend/BackendAPI/Infrastructure/HangfireDashboardAuthFilter.cs
+++ b/Backend/BackendAPI/Infrastructure/HangfireDashboardAuthFilter.cs
@@ -1,0 +1,77 @@
+using Hangfire.Dashboard;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace BackendAPI.Infrastructure
+{
+    /// <summary>
+    /// US-11 — Protects the Hangfire dashboard with HTTP Basic Auth in production.
+    ///
+    /// Config keys (appsettings.json / Azure App Settings):
+    ///   Hangfire:DashboardUser      — username  (default: "admin")
+    ///   Hangfire:DashboardPassword  — password  (CHANGE THIS before deploying)
+    ///
+    /// In Development the filter always returns true (no credentials needed).
+    /// </summary>
+    public class HangfireDashboardAuthFilter : IDashboardAuthorizationFilter
+    {
+        private readonly IConfiguration _config;
+        private readonly IWebHostEnvironment _env;
+
+        public HangfireDashboardAuthFilter(IConfiguration config, IWebHostEnvironment env)
+        {
+            _config = config;
+            _env    = env;
+        }
+
+        public bool Authorize(DashboardContext context)
+        {
+            // Dev: always allow — no credentials required
+            if (_env.IsDevelopment()) return true;
+
+            var httpContext = context.GetHttpContext();
+
+            // Read expected credentials from config
+            var expectedUser = _config["Hangfire:DashboardUser"]     ?? "admin";
+            var expectedPass = _config["Hangfire:DashboardPassword"]  ?? "";
+
+            // If no password configured in prod — block access entirely (fail safe)
+            if (string.IsNullOrWhiteSpace(expectedPass))
+            {
+                httpContext.Response.StatusCode = 403;
+                return false;
+            }
+
+            // Parse Authorization: Basic <base64> header
+            var authHeader = httpContext.Request.Headers["Authorization"].FirstOrDefault();
+            if (authHeader != null && authHeader.StartsWith("Basic ", StringComparison.OrdinalIgnoreCase))
+            {
+                try
+                {
+                    var encoded    = authHeader["Basic ".Length..].Trim();
+                    var decoded    = Encoding.UTF8.GetString(Convert.FromBase64String(encoded));
+                    var colonIndex = decoded.IndexOf(':');
+
+                    if (colonIndex > 0)
+                    {
+                        var user = decoded[..colonIndex];
+                        var pass = decoded[(colonIndex + 1)..];
+
+                        if (user == expectedUser && pass == expectedPass)
+                            return true;
+                    }
+                }
+                catch
+                {
+                    // Malformed header — fall through to challenge
+                }
+            }
+
+            // No valid credentials — send WWW-Authenticate challenge so the browser
+            // shows a login dialog instead of a blank 401 page
+            httpContext.Response.Headers["WWW-Authenticate"] = "Basic realm=\"Hangfire Dashboard\"";
+            httpContext.Response.StatusCode = 401;
+            return false;
+        }
+    }
+}

--- a/Backend/BackendAPI/Program.cs
+++ b/Backend/BackendAPI/Program.cs
@@ -1,4 +1,5 @@
 using BackendAPI.Data;
+using BackendAPI.Infrastructure;
 using BackendAPI.Interfaces;
 using BackendAPI.Jobs;
 using BackendAPI.Models;
@@ -65,6 +66,9 @@ builder.Services.AddScoped<IPollGenerationService,   PollGenerationService>();
 builder.Services.AddScoped<IngestionJob>();
 builder.Services.AddScoped<PollGenerationJob>();
 
+// ── Hangfire Dashboard Auth (US-11) ───────────────────────────────────────
+builder.Services.AddSingleton<HangfireDashboardAuthFilter>();
+
 // ── Hangfire (US-02) ──────────────────────────────────────────────────────
 var hangfireConn = builder.Configuration.GetConnectionString("DefaultConnection")!;
 builder.Services.AddHangfire(config => config
@@ -103,10 +107,15 @@ if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
     app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "Pollify API v1"));
-
-    // Hangfire Dashboard — dev only (no auth); US-11 adds Basic Auth for prod
-    app.UseHangfireDashboard("/hangfire");
 }
+
+// Hangfire Dashboard — available in all environments.
+// US-11: HangfireDashboardAuthFilter allows all in Dev, enforces Basic Auth in Prod.
+var authFilter = app.Services.GetRequiredService<HangfireDashboardAuthFilter>();
+app.UseHangfireDashboard("/hangfire", new DashboardOptions
+{
+    Authorization = new[] { authFilter }
+});
 
 app.UseHttpsRedirection();
 app.UseCors("FrontendPolicy");

--- a/Backend/BackendAPI/appsettings.json
+++ b/Backend/BackendAPI/appsettings.json
@@ -21,6 +21,10 @@
     "BaseUrl": "",
     "ApiKey": ""
   },
+  "Hangfire": {
+    "DashboardUser": "admin",
+    "DashboardPassword": "CHANGE_ME_before_deploying"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
- HangfireDashboardAuthFilter implements IDashboardAuthorizationFilter
- Dev: always allows access (no credentials required)
- Prod: enforces Basic Auth via Authorization header; blocks if password not configured (fail-safe)
- Sends WWW-Authenticate challenge so browser shows native login dialog
- Config keys: Hangfire:DashboardUser, Hangfire:DashboardPassword (appsettings.json)
- Dashboard now mounted on /hangfire in all environments (not just dev)