### PR TITLE
fix: add permissions block to demo caller workflows

### DIFF
--- a/.github/workflows/demo-deploy-pilot.yml
+++ b/.github/workflows/demo-deploy-pilot.yml
@@ -24,6 +24,11 @@ on:
         required: true
         default: "demo"
 
+permissions:
+  id-token: write
+  contents: read
+  actions: read
+
 jobs:
   deploy-pilot:
     name: Deploy demo app → pilot

--- a/.github/workflows/demo-promote.yml
+++ b/.github/workflows/demo-promote.yml
@@ -24,6 +24,11 @@ on:
         required: true
         default: "demo"
 
+permissions:
+  id-token: write
+  contents: read
+  actions: read
+
 jobs:
   promote:
     name: Promote demo app pilot → main


### PR DESCRIPTION
## Summary

- Adds `permissions: id-token: write, contents: read, actions: read` to `demo-deploy-pilot.yml` and `demo-promote.yml`
- Without this, GitHub rejects the workflow with: *"The workflow is requesting 'actions: read, id-token: write', but is only allowed 'actions: none, id-token: none'"*

## Root cause

Caller workflows must explicitly grant the same permissions that the reusable workflow (`aca-deploy.yml`) declares. The original PR merged without this block.

https://claude.ai/code/session_01CeUMVaceG8Uot613FrorES

---
_Generated by [Claude Code](https://claude.ai/code/session_01CeUMVaceG8Uot613FrorES)_