### PR TITLE
fix: correct COPY paths in demo Dockerfile

### DIFF
--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -2,10 +2,10 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-COPY requirements.txt .
+COPY demo/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app.py .
+COPY demo/app.py .
 
 EXPOSE 8080
 


### PR DESCRIPTION
## Summary

The `demo/Dockerfile` was reverted to the old paths. This restores the correct repo-root-relative paths so the Docker build succeeds when the build context is `.`:

- `COPY demo/requirements.txt .`
- `COPY demo/app.py .`

https://claude.ai/code/session_01CeUMVaceG8Uot613FrorES

---
_Generated by [Claude Code](https://claude.ai/code/session_01CeUMVaceG8Uot613FrorES)_