### PR TITLE
Fix frontend API base URL configuration

### DIFF
--- a/Frontend/.env.local.example
+++ b/Frontend/.env.local.example
@@ -1,7 +1,7 @@
 # Copy this file to .env.local and fill in your values
 
 # URL of your running ASP.NET Core backend
-NEXT_PUBLIC_API_URL=http://localhost:5000
+NEXT_PUBLIC_API_URL=http://localhost:5177
 
 # Google OAuth Client ID (from Google Cloud Console)
 # https://console.cloud.google.com/ → APIs & Services → Credentials

--- a/Frontend/lib/api.ts
+++ b/Frontend/lib/api.ts
@@ -5,8 +5,7 @@
  */
 
 import { getToken } from "@/lib/auth"
-
-const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5177"
+import { API_BASE_URL } from "@/lib/config"
 
 // ── Raw backend shapes ────────────────────────────────────────────────────────
 
@@ -63,7 +62,7 @@ function authHeaders(): Record<string, string> {
 }
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(`${BASE_URL}${path}`, {
+  const res = await fetch(`${API_BASE_URL}${path}`, {
     headers: {
       "Content-Type": "application/json",
       ...authHeaders(),          // attach JWT when logged in (US-18)

--- a/Frontend/lib/auth.ts
+++ b/Frontend/lib/auth.ts
@@ -1,4 +1,5 @@
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5000"
+import { API_BASE_URL } from "@/lib/config"
+
 const TOKEN_KEY = "pollify_token"
 const USER_KEY  = "pollify_user"
 
@@ -51,7 +52,7 @@ export function clearSession() {
 // ── API calls ─────────────────────────────────────────────────────────────
 
 async function post<T>(path: string, body: unknown): Promise<T> {
-  const res = await fetch(`${API_BASE}${path}`, {
+  const res = await fetch(`${API_BASE_URL}${path}`, {
     method:  "POST",
     headers: { "Content-Type": "application/json" },
     body:    JSON.stringify(body),

--- a/Frontend/lib/config.ts
+++ b/Frontend/lib/config.ts
@@ -1,0 +1,2 @@
+export const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5177"

--- a/README.md
+++ b/README.md
@@ -30,14 +30,20 @@ A gamified public opinion polling platform built with Next.js, TypeScript, and T
 # 1. Go into the Frontend folder
 cd Frontend
 
-# 2. Install dependencies
+# 2. Copy the example environment file and confirm the backend URL
+copy .env.local.example .env.local
+
+# 3. Install dependencies
 npm install --legacy-peer-deps
 
-# 3. Start the development server
+# 4. Start the development server
 npm run dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) in your browser.
+
+By default, the frontend expects the ASP.NET Core backend at `http://localhost:5177`.
+Override it with `NEXT_PUBLIC_API_URL` when needed.
 
 ### Other commands
 


### PR DESCRIPTION
## Summary
- Add a shared frontend API base URL helper
- Update auth and general API clients to use the same backend URL source
- Align the example env file and README with the backend launch URL

Closes #48

## Verification
- `./node_modules/.bin/tsc --noEmit` passed
- `npm run lint` could not run because `eslint` is not installed/declared in `Frontend/package.json`