### PR TITLE
Require authentication and ownership for poll creation

### DIFF
--- a/Backend/BackendAPI/Controllers/PollsController.cs
+++ b/Backend/BackendAPI/Controllers/PollsController.cs
@@ -1,5 +1,6 @@
 using BackendAPI.Interfaces;
 using BackendAPI.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Security.Claims;
 
@@ -44,23 +45,27 @@ namespace BackendAPI.Controllers
         [HttpGet("{id}")]
         public async Task<IActionResult> GetById(long id)
         {
-            var poll = await _pollsRepo.GetByIdAsync(id);
+            var poll = await _pollsRepo.GetByIdAsync(id, CurrentUserId());
             if (poll == null) return NotFound(new { message = $"Poll {id} not found." });
             return Ok(poll);
         }
 
         // POST /api/polls
         [HttpPost]
+        [Authorize]
         public async Task<IActionResult> Create([FromBody] CreatePollRequest request)
         {
+            var userId = CurrentUserId();
+            if (userId == null) return Unauthorized(new { message = "Invalid token." });
+
             if (request.Options.Count < 2)
                 return BadRequest(new { message = "A poll must have at least 2 options." });
 
             if (request.ExpiresAt <= DateTime.UtcNow)
                 return BadRequest(new { message = "ExpiresAt must be in the future." });
 
-            var id = await _pollsRepo.CreateAsync(request);
-            var poll = await _pollsRepo.GetByIdAsync(id);
+            var id = await _pollsRepo.CreateAsync(request, userId);
+            var poll = await _pollsRepo.GetByIdAsync(id, userId);
             return CreatedAtAction(nameof(GetById), new { id }, poll);
         }
 

--- a/Backend/BackendAPI/Interfaces/IPollsRepository.cs
+++ b/Backend/BackendAPI/Interfaces/IPollsRepository.cs
@@ -6,10 +6,10 @@ namespace BackendAPI.Interfaces
     {
         /// <param name="userId">When provided, HasVoted / UserVotedOptionId are populated.</param>
         Task<IEnumerable<Poll>> GetAllAsync(long? userId = null);
-        Task<Poll?> GetByIdAsync(long id);
+        Task<Poll?> GetByIdAsync(long id, long? userId = null);
         Task<IEnumerable<Poll>> GetTrendingAsync(int count = 10, long? userId = null);
         Task<IEnumerable<Poll>> GetRecentAsync(int count = 10);
-        Task<long> CreateAsync(CreatePollRequest request);
+        Task<long> CreateAsync(CreatePollRequest request, long? createdByUserId = null);
         Task<bool> DeleteAsync(long id);
         Task UpdateTrendingAsync();
     }

--- a/Backend/BackendAPI/Migrations/US49_Poll_Ownership.sql
+++ b/Backend/BackendAPI/Migrations/US49_Poll_Ownership.sql
@@ -1,0 +1,39 @@
+-- ============================================================
+-- US-49: Poll ownership migration
+-- Adds nullable creator ownership to Polls and keeps existing
+-- system/AI-generated polls valid with NULL CreatedByUserId.
+-- Idempotent - safe to run multiple times.
+-- ============================================================
+
+IF NOT EXISTS (
+    SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_NAME = 'Polls' AND COLUMN_NAME = 'CreatedByUserId'
+)
+BEGIN
+    ALTER TABLE Polls ADD CreatedByUserId BIGINT NULL;
+    PRINT 'Polls.CreatedByUserId column added.';
+END
+ELSE
+    PRINT 'Polls.CreatedByUserId already exists - skipped.';
+
+IF NOT EXISTS (
+    SELECT 1 FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+    WHERE TABLE_NAME = 'Polls' AND CONSTRAINT_NAME = 'FK_Polls_CreatedByUser'
+)
+BEGIN
+    EXEC('ALTER TABLE Polls ADD CONSTRAINT FK_Polls_CreatedByUser FOREIGN KEY (CreatedByUserId) REFERENCES Users(Id)');
+    PRINT 'FK_Polls_CreatedByUser constraint added.';
+END
+ELSE
+    PRINT 'FK_Polls_CreatedByUser already exists - skipped.';
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE name = 'IX_Polls_CreatedByUserId' AND object_id = OBJECT_ID('Polls')
+)
+BEGIN
+    EXEC('CREATE INDEX IX_Polls_CreatedByUserId ON Polls(CreatedByUserId) WHERE CreatedByUserId IS NOT NULL');
+    PRINT 'IX_Polls_CreatedByUserId index added.';
+END
+ELSE
+    PRINT 'IX_Polls_CreatedByUserId already exists - skipped.';

--- a/Backend/BackendAPI/Models/Poll.cs
+++ b/Backend/BackendAPI/Models/Poll.cs
@@ -11,6 +11,9 @@ namespace BackendAPI.Models
         public DateTime ExpiresAt { get; set; }
         public DateTime CreatedAt { get; set; }
         public int TotalVotes { get; set; }
+        public long? CreatedByUserId { get; set; }
+        public string? CreatedByUsername { get; set; }
+        public string? CreatedByDisplayName { get; set; }
 
         // ── Ingestion / AI fields (US-01) ────────────────────────────────────
         /// <summary>Origin of the poll: "rss" | "youtube" | "gnews" | "manual"</summary>

--- a/Backend/BackendAPI/Repository/PollsRepository.cs
+++ b/Backend/BackendAPI/Repository/PollsRepository.cs
@@ -56,7 +56,12 @@ namespace BackendAPI.Repository
             var pollDict   = new Dictionary<long, Poll>();
 
             await conn.QueryAsync<Poll, PollOption, Poll>(
-                "SELECT p.*, o.* FROM Polls p LEFT JOIN PollOptions o ON o.PollId = p.Id WHERE p.IsActive = 1 ORDER BY p.CreatedAt DESC",
+                @"SELECT p.*, u.Username AS CreatedByUsername, u.DisplayName AS CreatedByDisplayName, o.*
+                  FROM Polls p
+                  LEFT JOIN Users u ON u.Id = p.CreatedByUserId
+                  LEFT JOIN PollOptions o ON o.PollId = p.Id
+                  WHERE p.IsActive = 1
+                  ORDER BY p.CreatedAt DESC",
                 (poll, option) =>
                 {
                     if (!pollDict.TryGetValue(poll.Id, out var existing))
@@ -77,13 +82,17 @@ namespace BackendAPI.Repository
 
         // ── GetById ───────────────────────────────────────────────────────────
 
-        public async Task<Poll?> GetByIdAsync(long id)
+        public async Task<Poll?> GetByIdAsync(long id, long? userId = null)
         {
             using var conn = _context.CreateConnection();
             var pollDict   = new Dictionary<long, Poll>();
 
             await conn.QueryAsync<Poll, PollOption, Poll>(
-                "SELECT p.*, o.* FROM Polls p LEFT JOIN PollOptions o ON o.PollId = p.Id WHERE p.Id = @Id",
+                @"SELECT p.*, u.Username AS CreatedByUsername, u.DisplayName AS CreatedByDisplayName, o.*
+                  FROM Polls p
+                  LEFT JOIN Users u ON u.Id = p.CreatedByUserId
+                  LEFT JOIN PollOptions o ON o.PollId = p.Id
+                  WHERE p.Id = @Id",
                 (poll, option) =>
                 {
                     if (!pollDict.TryGetValue(poll.Id, out var existing))
@@ -99,7 +108,8 @@ namespace BackendAPI.Repository
                 splitOn: "Id"
             );
 
-            return pollDict.Values.FirstOrDefault();
+            var userVotes = await GetUserVotesAsync(userId);
+            return ApplyVoteState(pollDict.Values, userVotes).FirstOrDefault();
         }
 
         // ── GetTrending ───────────────────────────────────────────────────────
@@ -111,8 +121,9 @@ namespace BackendAPI.Repository
 
             // US-09: order by TotalVotes DESC directly
             await conn.QueryAsync<Poll, PollOption, Poll>(
-                @"SELECT TOP (@Count) p.*, o.*
+                @"SELECT TOP (@Count) p.*, u.Username AS CreatedByUsername, u.DisplayName AS CreatedByDisplayName, o.*
                   FROM Polls p
+                  LEFT JOIN Users u ON u.Id = p.CreatedByUserId
                   LEFT JOIN PollOptions o ON o.PollId = p.Id
                   WHERE p.IsActive = 1
                   ORDER BY p.TotalVotes DESC, p.CreatedAt DESC",
@@ -143,8 +154,9 @@ namespace BackendAPI.Repository
             var pollDict   = new Dictionary<long, Poll>();
 
             await conn.QueryAsync<Poll, PollOption, Poll>(
-                @"SELECT TOP (@Count) p.*, o.*
+                @"SELECT TOP (@Count) p.*, u.Username AS CreatedByUsername, u.DisplayName AS CreatedByDisplayName, o.*
                   FROM Polls p
+                  LEFT JOIN Users u ON u.Id = p.CreatedByUserId
                   LEFT JOIN PollOptions o ON o.PollId = p.Id
                   WHERE p.IsActive = 1
                   ORDER BY p.CreatedAt DESC",
@@ -168,7 +180,7 @@ namespace BackendAPI.Repository
 
         // ── Create ────────────────────────────────────────────────────────────
 
-        public async Task<long> CreateAsync(CreatePollRequest request)
+        public async Task<long> CreateAsync(CreatePollRequest request, long? createdByUserId = null)
         {
             using var conn = _context.CreateConnection();
             conn.Open();
@@ -179,11 +191,13 @@ namespace BackendAPI.Repository
                 var pollId = await conn.ExecuteScalarAsync<long>(
                     @"INSERT INTO Polls
                         (Question, Description, Category, ExpiresAt, IsActive, IsTrending,
+                         CreatedByUserId,
                          CreatedAt, TotalVotes, SourceType, SourceUrl, ThumbnailUrl, IsAIGenerated)
                       VALUES
                         (@Question, @Description, @Category, @ExpiresAt, 1, 0,
+                         @CreatedByUserId,
                          GETUTCDATE(), 0, @SourceType, @SourceUrl, @ThumbnailUrl, @IsAIGenerated);
-                      SELECT SCOPE_IDENTITY();",
+                      SELECT CAST(SCOPE_IDENTITY() AS BIGINT);",
                     new
                     {
                         request.Question,
@@ -193,7 +207,8 @@ namespace BackendAPI.Repository
                         request.SourceType,
                         request.SourceUrl,
                         request.ThumbnailUrl,
-                        request.IsAIGenerated
+                        request.IsAIGenerated,
+                        CreatedByUserId = createdByUserId
                     },
                     transaction
                 );
@@ -203,6 +218,15 @@ namespace BackendAPI.Repository
                     await conn.ExecuteAsync(
                         "INSERT INTO PollOptions (PollId, Text, VoteCount) VALUES (@PollId, @Text, 0)",
                         new { PollId = pollId, Text = optionText },
+                        transaction
+                    );
+                }
+
+                if (createdByUserId != null)
+                {
+                    await conn.ExecuteAsync(
+                        "UPDATE Users SET PollsCreated = PollsCreated + 1 WHERE Id = @UserId",
+                        new { UserId = createdByUserId },
                         transaction
                     );
                 }

--- a/Backend/TableAndSPCreation/CreateTables.sql
+++ b/Backend/TableAndSPCreation/CreateTables.sql
@@ -21,7 +21,8 @@ CREATE TABLE Polls (
     IsActive    BIT             NOT NULL DEFAULT 1,
     ExpiresAt   DATETIME2       NOT NULL,
     CreatedAt   DATETIME2       NOT NULL DEFAULT GETUTCDATE(),
-    TotalVotes  INT             NOT NULL DEFAULT 0
+    TotalVotes  INT             NOT NULL DEFAULT 0,
+    CreatedByUserId BIGINT      NULL
 );
 GO
 
@@ -72,9 +73,15 @@ GO
 -- ============================================================
 CREATE INDEX IX_Polls_IsTrending  ON Polls(IsTrending) WHERE IsActive = 1;
 CREATE INDEX IX_Polls_CreatedAt   ON Polls(CreatedAt DESC);
+CREATE INDEX IX_Polls_CreatedByUserId ON Polls(CreatedByUserId) WHERE CreatedByUserId IS NOT NULL;
 CREATE INDEX IX_PollOptions_PollId ON PollOptions(PollId);
 CREATE INDEX IX_Votes_PollId       ON Votes(PollId);
 CREATE INDEX IX_Users_Xp           ON Users(Xp DESC);
+GO
+
+ALTER TABLE Polls
+    ADD CONSTRAINT FK_Polls_CreatedByUser
+    FOREIGN KEY (CreatedByUserId) REFERENCES Users(Id);
 GO
 
 -- ============================================================

--- a/Frontend/app/create/page.tsx
+++ b/Frontend/app/create/page.tsx
@@ -1,7 +1,21 @@
 "use client"
 
+import { useEffect } from "react"
+import { useRouter } from "next/navigation"
 import { PollCreator } from "@/components/poll-create"
+import { useAuth } from "@/contexts/auth-context"
 
 export default function CreatePollPage() {
+  const router = useRouter()
+  const { isAuthenticated, isLoading } = useAuth()
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      router.replace("/login")
+    }
+  }, [isAuthenticated, isLoading, router])
+
+  if (isLoading || !isAuthenticated) return null
+
   return <PollCreator />
 }

--- a/Frontend/lib/api.ts
+++ b/Frontend/lib/api.ts
@@ -27,6 +27,9 @@ export interface ApiPoll {
   expiresAt: string          // ISO date string
   createdAt: string          // ISO date string
   totalVotes: number
+  createdByUserId: number | null
+  createdByUsername: string | null
+  createdByDisplayName: string | null
   sourceType: string | null
   sourceUrl: string | null
   thumbnailUrl: string | null


### PR DESCRIPTION
## Summary
- Require JWT auth for `POST /api/polls`
- Persist nullable poll creator ownership and return creator metadata on poll responses
- Increment `Users.PollsCreated` when an authenticated user creates a poll
- Add an idempotent poll ownership migration and update fresh database setup
- Redirect unauthenticated frontend users away from the create poll page

Closes #49

## Verification
- `dotnet build Backend\BackendAPI\BackendAPI.csproj` passed with one existing nullable warning in `AuthRepository.cs`
- `./node_modules/.bin/tsc --noEmit` passed
- `npm run lint` could not run because `eslint` is not installed/declared in `Frontend/package.json`