### PR TITLE
Implement daily streak and vote reward rules

### DIFF
--- a/Backend/BackendAPI/Controllers/VotesController.cs
+++ b/Backend/BackendAPI/Controllers/VotesController.cs
@@ -1,5 +1,6 @@
 using BackendAPI.Interfaces;
 using BackendAPI.Models;
+using BackendAPI.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Security.Claims;
@@ -58,9 +59,11 @@ namespace BackendAPI.Controllers
                 return Conflict(new { message = "You have already voted on this poll." });
             }
 
-            // US-20: Award XP and increment streak/totalVotes for the authenticated user
-            int xpReward = poll.IsTrending ? 35 : 25;
-            await _usersRepo.UpdateXpAsync(userId, xpReward);
+            // US-50: Award XP and apply daily streak rules after a unique vote.
+            var reward = await _usersRepo.ApplyVoteRewardAsync(
+                userId,
+                GamificationRules.VoteXp(poll),
+                DateTime.UtcNow);
 
             // Return updated poll with hasVoted populated for this user
             var updated = await _pollsRepo.GetByIdAsync(request.PollId);
@@ -69,7 +72,11 @@ namespace BackendAPI.Controllers
                 updated.HasVoted          = true;
                 updated.UserVotedOptionId = request.OptionId;
             }
-            return Ok(updated);
+            return Ok(new CastVoteResponse
+            {
+                Poll = updated!,
+                Reward = reward
+            });
         }
 
         // GET /api/votes/{pollId}

--- a/Backend/BackendAPI/Interfaces/IUsersRepository.cs
+++ b/Backend/BackendAPI/Interfaces/IUsersRepository.cs
@@ -8,8 +8,7 @@ namespace BackendAPI.Interfaces
         Task<User?> GetByIdAsync(long id);
         Task<User?> GetByUsernameAsync(string username);
         Task<long> CreateAsync(CreateUserRequest request);
-        Task UpdateXpAsync(long userId, int xpToAdd);
-        Task UpdateStreakAsync(long userId);
+        Task<VoteRewardResult> ApplyVoteRewardAsync(long userId, int xpToAdd, DateTime utcNow);
         /// <summary>US-22: Returns the user's vote history with poll details.</summary>
         Task<IEnumerable<VoteHistoryItem>> GetVoteHistoryAsync(long userId, int count = 20);
     }

--- a/Backend/BackendAPI/Migrations/US50_User_Streak_Rules.sql
+++ b/Backend/BackendAPI/Migrations/US50_User_Streak_Rules.sql
@@ -1,0 +1,17 @@
+-- ============================================================
+-- US-50: Daily streak support
+-- Adds LastVoteDate so XP can be awarded on every unique vote
+-- while streaks advance at most once per UTC day.
+-- Idempotent - safe to run multiple times.
+-- ============================================================
+
+IF NOT EXISTS (
+    SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_NAME = 'Users' AND COLUMN_NAME = 'LastVoteDate'
+)
+BEGIN
+    ALTER TABLE Users ADD LastVoteDate DATE NULL;
+    PRINT 'Users.LastVoteDate column added.';
+END
+ELSE
+    PRINT 'Users.LastVoteDate already exists - skipped.';

--- a/Backend/BackendAPI/Models/Auth.cs
+++ b/Backend/BackendAPI/Models/Auth.cs
@@ -43,6 +43,7 @@ namespace BackendAPI.Models
         public int Streak { get; set; }
         public int TotalVotes { get; set; }
         public int PollsCreated { get; set; }
+        public DateTime? LastVoteDate { get; set; }
         public DateTime CreatedAt { get; set; }
     }
 }

--- a/Backend/BackendAPI/Models/User.cs
+++ b/Backend/BackendAPI/Models/User.cs
@@ -9,6 +9,7 @@ namespace BackendAPI.Models
         public int Streak { get; set; }
         public int TotalVotes { get; set; }
         public int PollsCreated { get; set; }
+        public DateTime? LastVoteDate { get; set; }
         public DateTime CreatedAt { get; set; }
     }
 
@@ -27,5 +28,15 @@ namespace BackendAPI.Models
         public string VotedOptionText  { get; set; } = string.Empty;
         public int    TotalVotes       { get; set; }
         public DateTime VotedAt        { get; set; }
+    }
+
+    public class VoteRewardResult
+    {
+        public int Xp { get; set; }
+        public int Streak { get; set; }
+        public int TotalVotes { get; set; }
+        public int XpAwarded { get; set; }
+        public bool StreakAdvanced { get; set; }
+        public DateTime? LastVoteDate { get; set; }
     }
 }

--- a/Backend/BackendAPI/Models/Vote.cs
+++ b/Backend/BackendAPI/Models/Vote.cs
@@ -15,4 +15,10 @@ namespace BackendAPI.Models
         public long OptionId { get; set; }
         // UserId is NOT accepted from the client — set server-side from JWT (US-15)
     }
+
+    public class CastVoteResponse
+    {
+        public Poll Poll { get; set; } = new();
+        public VoteRewardResult Reward { get; set; } = new();
+    }
 }

--- a/Backend/BackendAPI/Repository/AuthRepository.cs
+++ b/Backend/BackendAPI/Repository/AuthRepository.cs
@@ -126,7 +126,7 @@ namespace BackendAPI.Repository
             using var conn = _context.CreateConnection();
             return await conn.QueryFirstOrDefaultAsync<UserResponse>(
                 @"SELECT Id, Username, DisplayName, Email, AvatarUrl, AuthProvider,
-                         Xp, Streak, TotalVotes, PollsCreated, CreatedAt
+                         Xp, Streak, TotalVotes, PollsCreated, LastVoteDate, CreatedAt
                   FROM Users WHERE Id = @Id",
                 new { Id = id }
             );

--- a/Backend/BackendAPI/Repository/UsersRepository.cs
+++ b/Backend/BackendAPI/Repository/UsersRepository.cs
@@ -1,6 +1,7 @@
 using BackendAPI.Data;
 using BackendAPI.Interfaces;
 using BackendAPI.Models;
+using BackendAPI.Services;
 using Dapper;
 
 namespace BackendAPI.Repository
@@ -52,22 +53,51 @@ namespace BackendAPI.Repository
             );
         }
 
-        public async Task UpdateXpAsync(long userId, int xpToAdd)
+        public async Task<VoteRewardResult> ApplyVoteRewardAsync(long userId, int xpToAdd, DateTime utcNow)
         {
             using var conn = _context.CreateConnection();
-            await conn.ExecuteAsync(
-                "UPDATE Users SET Xp = Xp + @Xp, TotalVotes = TotalVotes + 1 WHERE Id = @Id",
-                new { Xp = xpToAdd, Id = userId }
-            );
-        }
+            conn.Open();
+            using var transaction = conn.BeginTransaction();
 
-        public async Task UpdateStreakAsync(long userId)
-        {
-            using var conn = _context.CreateConnection();
-            await conn.ExecuteAsync(
-                "UPDATE Users SET Streak = Streak + 1 WHERE Id = @Id",
-                new { Id = userId }
+            var user = await conn.QuerySingleAsync<User>(
+                @"SELECT Id, Xp, Streak, TotalVotes, LastVoteDate
+                  FROM Users WITH (UPDLOCK, ROWLOCK)
+                  WHERE Id = @Id",
+                new { Id = userId },
+                transaction
             );
+
+            var streak = GamificationRules.ApplyDailyStreak(
+                user.Streak,
+                user.LastVoteDate,
+                utcNow);
+
+            var updated = await conn.QuerySingleAsync<VoteRewardResult>(
+                @"UPDATE Users
+                  SET Xp = Xp + @XpAwarded,
+                      TotalVotes = TotalVotes + 1,
+                      Streak = @Streak,
+                      LastVoteDate = @LastVoteDate
+                  OUTPUT inserted.Xp,
+                         inserted.Streak,
+                         inserted.TotalVotes,
+                         @XpAwarded AS XpAwarded,
+                         @StreakAdvanced AS StreakAdvanced,
+                         inserted.LastVoteDate
+                  WHERE Id = @Id",
+                new
+                {
+                    Id = userId,
+                    XpAwarded = xpToAdd,
+                    streak.Streak,
+                    streak.StreakAdvanced,
+                    streak.LastVoteDate
+                },
+                transaction
+            );
+
+            transaction.Commit();
+            return updated;
         }
 
         // US-22: Vote history ─────────────────────────────────────────────────

--- a/Backend/BackendAPI/Services/GamificationRules.cs
+++ b/Backend/BackendAPI/Services/GamificationRules.cs
@@ -1,0 +1,34 @@
+using BackendAPI.Models;
+
+namespace BackendAPI.Services
+{
+    public static class GamificationRules
+    {
+        public static int VoteXp(Poll poll) => poll.IsTrending ? 35 : 25;
+
+        public static StreakUpdate ApplyDailyStreak(
+            int currentStreak,
+            DateTime? lastVoteDate,
+            DateTime utcNow)
+        {
+            var today = utcNow.Date;
+            var previousVoteDate = lastVoteDate?.Date;
+
+            if (previousVoteDate == today)
+            {
+                return new StreakUpdate(currentStreak, false, today);
+            }
+
+            var nextStreak = previousVoteDate == today.AddDays(-1)
+                ? currentStreak + 1
+                : 1;
+
+            return new StreakUpdate(nextStreak, true, today);
+        }
+    }
+
+    public sealed record StreakUpdate(
+        int Streak,
+        bool StreakAdvanced,
+        DateTime LastVoteDate);
+}

--- a/Backend/TableAndSPCreation/CreateTables.sql
+++ b/Backend/TableAndSPCreation/CreateTables.sql
@@ -64,6 +64,7 @@ CREATE TABLE Users (
     Streak       INT            NOT NULL DEFAULT 0,
     TotalVotes   INT            NOT NULL DEFAULT 0,
     PollsCreated INT            NOT NULL DEFAULT 0,
+    LastVoteDate DATE           NULL,
     CreatedAt    DATETIME2      NOT NULL DEFAULT GETUTCDATE()
 );
 GO

--- a/Frontend/hooks/use-polls.ts
+++ b/Frontend/hooks/use-polls.ts
@@ -63,11 +63,11 @@ export function usePolls(): UsePollsResult {
   // Cast a vote — optimistically update percentages
   const castVote = useCallback(async (pollId: string, optionId: number) => {
     try {
-      const updated = await votesApi.cast({
+      const result = await votesApi.cast({
         pollId:   Number(pollId),
         optionId,
       })
-      const mapped = mapBackendPoll(updated)
+      const mapped = mapBackendPoll(result.poll)
       setPolls((prev) =>
         prev.map((p) => (p.id === pollId ? mapped : p))
       )

--- a/Frontend/lib/api.ts
+++ b/Frontend/lib/api.ts
@@ -45,6 +45,20 @@ export interface CastVoteRequest {
   optionId: number
 }
 
+export interface ApiVoteReward {
+  xp: number
+  streak: number
+  totalVotes: number
+  xpAwarded: number
+  streakAdvanced: boolean
+  lastVoteDate: string | null
+}
+
+export interface ApiCastVoteResponse {
+  poll: ApiPoll
+  reward: ApiVoteReward
+}
+
 export interface CreatePollPayload {
   question: string
   description: string
@@ -105,7 +119,7 @@ export const pollsApi = {
 export const votesApi = {
   /** Cast a vote — requires authentication. Returns the updated poll. */
   cast: (req: CastVoteRequest) =>
-    request<ApiPoll>("/api/votes", {
+    request<ApiCastVoteResponse>("/api/votes", {
       method: "POST",
       body: JSON.stringify(req),
     }),
@@ -124,6 +138,7 @@ export interface ApiUser {
   streak: number
   totalVotes: number
   pollsCreated: number
+  lastVoteDate?: string | null
   createdAt: string
 }
 

--- a/Frontend/lib/auth.ts
+++ b/Frontend/lib/auth.ts
@@ -14,6 +14,7 @@ export interface AuthUser {
   streak: number
   totalVotes: number
   pollsCreated: number
+  lastVoteDate?: string | null
   createdAt: string
 }
 


### PR DESCRIPTION
## Summary
- Add centralized gamification rules for vote XP and daily streak progression
- Track `Users.LastVoteDate` so streaks advance at most once per UTC day
- Replace ad hoc XP updates with an atomic vote reward update that returns XP, streak, total votes, and reward metadata
- Return `{ poll, reward }` from `POST /api/votes` and update the frontend vote client to consume the new shape
- Add an idempotent US-50 migration and update fresh DB setup

Closes #50

## Verification
- `dotnet build Backend\BackendAPI\BackendAPI.csproj` passed with one existing nullable warning in `AuthRepository.cs`
- `./node_modules/.bin/tsc --noEmit` passed
- `npm run lint` could not run because `eslint` is not installed/declared in `Frontend/package.json`

## Test note
- The repo does not currently contain a backend test project, so no unit test runner is available yet. The streak math is centralized in `GamificationRules.ApplyDailyStreak` to make it straightforward to cover when a test project is added.