### PR TITLE
Add mobile poll feed and voting flow

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,10 +1,12 @@
 import { StatusBar } from 'expo-status-bar';
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   ActivityIndicator,
+  FlatList,
   KeyboardAvoidingView,
   Platform,
   Pressable,
+  RefreshControl,
   SafeAreaView,
   ScrollView,
   StyleSheet,
@@ -15,6 +17,8 @@ import {
 
 import { API_BASE_URL } from './src/config/api';
 import { AuthProvider, useAuth } from './src/context/AuthContext';
+import { pollsApi, votesApi } from './src/lib/api';
+import type { ApiPoll, ApiPollOption, VoteReward } from './src/types/poll';
 
 type AuthMode = 'login' | 'register';
 
@@ -223,44 +227,120 @@ function LabeledInput({
 }
 
 function SignedInHome() {
-  const { signOut, user } = useAuth();
+  const { applyVoteReward, signOut, user } = useAuth();
+  const [polls, setPolls] = useState<ApiPoll[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [votingPollId, setVotingPollId] = useState<number | null>(null);
+  const [latestReward, setLatestReward] = useState<VoteReward | null>(null);
+
+  const loadPolls = useCallback(async (refreshing = false) => {
+    if (refreshing) {
+      setIsRefreshing(true);
+    } else {
+      setIsLoading(true);
+    }
+
+    setError(null);
+
+    try {
+      setPolls(await pollsApi.getTrending(20));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not load polls');
+    } finally {
+      setIsLoading(false);
+      setIsRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadPolls();
+  }, [loadPolls]);
+
+  async function vote(pollId: number, optionId: number) {
+    setVotingPollId(pollId);
+    setError(null);
+
+    try {
+      const response = await votesApi.cast(pollId, optionId);
+      setPolls((current) =>
+        current.map((poll) => (poll.id === response.poll.id ? response.poll : poll)),
+      );
+      setLatestReward(response.reward);
+      applyVoteReward(response.reward);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not record your vote');
+    } finally {
+      setVotingPollId(null);
+    }
+  }
 
   if (!user) return null;
 
   return (
-    <ScrollView contentContainerStyle={styles.container}>
-      <View style={styles.heroCompact}>
-        <Text style={styles.eyebrow}>Pollify</Text>
-        <Text style={styles.titleSmall}>Hi, {user.displayName}</Text>
-        <Text style={styles.subtitle}>
-          Your mobile session is active and ready for poll feed integration.
-        </Text>
-      </View>
-
-      <View style={styles.profilePanel}>
+    <View style={styles.feedShell}>
+      <View style={styles.feedHeader}>
         <View>
-          <Text style={styles.profileName}>{user.displayName}</Text>
-          <Text style={styles.profileUsername}>@{user.username}</Text>
+          <Text style={styles.eyebrow}>Pollify</Text>
+          <Text style={styles.feedTitle}>Hi, {user.displayName}</Text>
         </View>
-        <View style={styles.metricGrid}>
-          <Metric label="XP" value={String(user.xp ?? 0)} />
-          <Metric label="Streak" value={String(user.streak ?? 0)} />
-          <Metric label="Votes" value={String(user.totalVotes ?? 0)} />
-          <Metric label="Polls" value={String(user.pollsCreated ?? 0)} />
-        </View>
-      </View>
-
-      <View style={styles.actionPanel}>
-        <Text style={styles.actionTitle}>Session stored securely</Text>
-        <Text style={styles.actionCopy}>
-          The JWT is saved with Expo SecureStore and refreshed from `/api/auth/me`
-          when the app starts.
-        </Text>
-        <Pressable onPress={signOut} style={styles.secondaryButton}>
-          <Text style={styles.secondaryButtonText}>Logout</Text>
+        <Pressable onPress={signOut} style={styles.logoutButton}>
+          <Text style={styles.logoutButtonText}>Logout</Text>
         </Pressable>
       </View>
-    </ScrollView>
+
+      <View style={styles.compactStats}>
+        <Metric label="XP" value={String(user.xp ?? 0)} />
+        <Metric label="Streak" value={String(user.streak ?? 0)} />
+        <Metric label="Votes" value={String(user.totalVotes ?? 0)} />
+      </View>
+
+      {latestReward && (
+        <View style={styles.rewardBanner}>
+          <Text style={styles.rewardTitle}>+{latestReward.xpAwarded} XP earned</Text>
+          <Text style={styles.rewardCopy}>
+            {latestReward.streakAdvanced
+              ? `Daily streak is now ${latestReward.streak}.`
+              : `Streak stays at ${latestReward.streak}.`}
+          </Text>
+        </View>
+      )}
+
+      {error && (
+        <View style={styles.feedError}>
+          <Text style={styles.feedErrorText}>{error}</Text>
+          <Pressable onPress={() => loadPolls()} style={styles.retryButton}>
+            <Text style={styles.retryButtonText}>Retry</Text>
+          </Pressable>
+        </View>
+      )}
+
+      {isLoading ? (
+        <View style={styles.feedState}>
+          <ActivityIndicator color="#B0413E" size="large" />
+          <Text style={styles.loadingText}>Loading trending polls</Text>
+        </View>
+      ) : (
+        <FlatList
+          contentContainerStyle={styles.feedList}
+          data={polls}
+          keyExtractor={(poll) => String(poll.id)}
+          ListEmptyComponent={<EmptyPollState onRetry={() => loadPolls()} />}
+          refreshControl={
+            <RefreshControl refreshing={isRefreshing} onRefresh={() => loadPolls(true)} />
+          }
+          renderItem={({ item }) => (
+            <PollCard
+              isVoting={votingPollId === item.id}
+              onVote={(optionId) => vote(item.id, optionId)}
+              poll={item}
+            />
+          )}
+          showsVerticalScrollIndicator={false}
+        />
+      )}
+    </View>
   );
 }
 
@@ -271,6 +351,119 @@ function Metric({ label, value }: { label: string; value: string }) {
       <Text style={styles.metricLabel}>{label}</Text>
     </View>
   );
+}
+
+function EmptyPollState({ onRetry }: { onRetry: () => void }) {
+  return (
+    <View style={styles.emptyState}>
+      <Text style={styles.emptyTitle}>No trending polls yet</Text>
+      <Text style={styles.emptyCopy}>
+        Pull to refresh or retry once the backend has generated fresh polls.
+      </Text>
+      <Pressable onPress={onRetry} style={styles.secondaryButton}>
+        <Text style={styles.secondaryButtonText}>Refresh</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+function PollCard({
+  isVoting,
+  onVote,
+  poll,
+}: {
+  isVoting: boolean;
+  onVote: (optionId: number) => void;
+  poll: ApiPoll;
+}) {
+  const expiresAt = new Date(poll.expiresAt);
+  const isExpired = !poll.isActive || expiresAt.getTime() < Date.now();
+  const canVote = !poll.hasVoted && !isExpired && !isVoting;
+
+  return (
+    <View style={styles.pollCard}>
+      <View style={styles.pollMetaRow}>
+        <Text style={styles.categoryPill}>{poll.category || 'General'}</Text>
+        <Text style={styles.pollMeta}>{poll.totalVotes} votes</Text>
+      </View>
+
+      <Text style={styles.pollQuestion}>{poll.question}</Text>
+      {Boolean(poll.description) && <Text style={styles.pollDescription}>{poll.description}</Text>}
+
+      <View style={styles.optionList}>
+        {poll.options.map((option) => (
+          <PollOptionButton
+            canVote={canVote}
+            isSelected={poll.userVotedOptionId === option.id}
+            isVoting={isVoting}
+            key={option.id}
+            onPress={() => onVote(option.id)}
+            option={option}
+            showResults={poll.hasVoted || isExpired}
+          />
+        ))}
+      </View>
+
+      <Text style={styles.pollFooter}>
+        {poll.hasVoted
+          ? 'Your vote is counted.'
+          : isExpired
+            ? 'This poll has ended.'
+            : `Ends ${formatRelativeDate(expiresAt)}`}
+      </Text>
+    </View>
+  );
+}
+
+function PollOptionButton({
+  canVote,
+  isSelected,
+  isVoting,
+  onPress,
+  option,
+  showResults,
+}: {
+  canVote: boolean;
+  isSelected: boolean;
+  isVoting: boolean;
+  onPress: () => void;
+  option: ApiPollOption;
+  showResults: boolean;
+}) {
+  const percentage = Math.round(option.votePercentage || 0);
+
+  return (
+    <Pressable
+      disabled={!canVote}
+      onPress={onPress}
+      style={[styles.optionButton, isSelected && styles.optionButtonSelected]}
+    >
+      {showResults && <View style={[styles.optionFill, { width: `${percentage}%` }]} />}
+      <View style={styles.optionContent}>
+        <Text style={[styles.optionText, isSelected && styles.optionTextSelected]}>
+          {option.text}
+        </Text>
+        {isVoting ? (
+          <ActivityIndicator color="#B0413E" />
+        ) : showResults ? (
+          <Text style={styles.optionPercent}>{percentage}%</Text>
+        ) : null}
+      </View>
+    </Pressable>
+  );
+}
+
+function formatRelativeDate(date: Date) {
+  if (Number.isNaN(date.getTime())) return 'soon';
+
+  const diffMs = date.getTime() - Date.now();
+  const diffHours = Math.ceil(diffMs / (1000 * 60 * 60));
+
+  if (diffHours <= 0) return 'soon';
+  if (diffHours < 24) return `in ${diffHours}h`;
+
+  const diffDays = Math.ceil(diffHours / 24);
+  return `in ${diffDays}d`;
 }
 
 const styles = StyleSheet.create({
@@ -298,6 +491,103 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '700',
     letterSpacing: 0,
+  },
+  feedShell: {
+    flex: 1,
+    paddingHorizontal: 18,
+    paddingTop: 18,
+  },
+  feedHeader: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingBottom: 14,
+  },
+  feedTitle: {
+    color: '#222222',
+    fontSize: 28,
+    fontWeight: '900',
+    letterSpacing: 0,
+    lineHeight: 34,
+  },
+  logoutButton: {
+    backgroundColor: '#FFFFFF',
+    borderColor: '#E6E0D4',
+    borderRadius: 8,
+    borderWidth: 1,
+    paddingHorizontal: 12,
+    paddingVertical: 9,
+  },
+  logoutButtonText: {
+    color: '#B0413E',
+    fontSize: 13,
+    fontWeight: '800',
+    letterSpacing: 0,
+  },
+  compactStats: {
+    flexDirection: 'row',
+    gap: 8,
+    paddingBottom: 12,
+  },
+  rewardBanner: {
+    backgroundColor: '#233D4D',
+    borderRadius: 8,
+    gap: 4,
+    marginBottom: 12,
+    padding: 14,
+  },
+  rewardTitle: {
+    color: '#F4D35E',
+    fontSize: 16,
+    fontWeight: '900',
+    letterSpacing: 0,
+  },
+  rewardCopy: {
+    color: '#E7EFF2',
+    fontSize: 14,
+    fontWeight: '700',
+    letterSpacing: 0,
+    lineHeight: 20,
+  },
+  feedError: {
+    alignItems: 'center',
+    backgroundColor: '#FBE9E7',
+    borderRadius: 8,
+    flexDirection: 'row',
+    gap: 10,
+    marginBottom: 12,
+    padding: 12,
+  },
+  feedErrorText: {
+    color: '#9F2E2B',
+    flex: 1,
+    fontSize: 14,
+    fontWeight: '700',
+    letterSpacing: 0,
+    lineHeight: 20,
+  },
+  retryButton: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  retryButtonText: {
+    color: '#9F2E2B',
+    fontSize: 13,
+    fontWeight: '900',
+    letterSpacing: 0,
+  },
+  feedState: {
+    alignItems: 'center',
+    flex: 1,
+    gap: 14,
+    justifyContent: 'center',
+    padding: 24,
+  },
+  feedList: {
+    gap: 14,
+    paddingBottom: 28,
   },
   hero: {
     paddingTop: 36,
@@ -455,6 +745,7 @@ const styles = StyleSheet.create({
     borderColor: '#E6E0D4',
     borderRadius: 8,
     borderWidth: 1,
+    flex: 1,
     minWidth: '47%',
     padding: 14,
   },
@@ -517,6 +808,126 @@ const styles = StyleSheet.create({
     color: '#1F2B32',
     fontSize: 16,
     fontWeight: '800',
+    letterSpacing: 0,
+  },
+  emptyState: {
+    alignItems: 'center',
+    backgroundColor: '#FFFFFF',
+    borderColor: '#E6E0D4',
+    borderRadius: 8,
+    borderWidth: 1,
+    gap: 12,
+    padding: 22,
+  },
+  emptyTitle: {
+    color: '#222222',
+    fontSize: 20,
+    fontWeight: '900',
+    letterSpacing: 0,
+    textAlign: 'center',
+  },
+  emptyCopy: {
+    color: '#54514A',
+    fontSize: 15,
+    letterSpacing: 0,
+    lineHeight: 22,
+    textAlign: 'center',
+  },
+  pollCard: {
+    backgroundColor: '#FFFFFF',
+    borderColor: '#E6E0D4',
+    borderRadius: 8,
+    borderWidth: 1,
+    gap: 14,
+    padding: 16,
+  },
+  pollMetaRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  categoryPill: {
+    backgroundColor: '#F4D35E',
+    borderRadius: 8,
+    color: '#1F2B32',
+    fontSize: 12,
+    fontWeight: '900',
+    letterSpacing: 0,
+    overflow: 'hidden',
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    textTransform: 'uppercase',
+  },
+  pollMeta: {
+    color: '#756F63',
+    fontSize: 13,
+    fontWeight: '800',
+    letterSpacing: 0,
+  },
+  pollQuestion: {
+    color: '#222222',
+    fontSize: 21,
+    fontWeight: '900',
+    letterSpacing: 0,
+    lineHeight: 27,
+  },
+  pollDescription: {
+    color: '#54514A',
+    fontSize: 15,
+    letterSpacing: 0,
+    lineHeight: 22,
+  },
+  optionList: {
+    gap: 10,
+  },
+  optionButton: {
+    backgroundColor: '#F9F7F2',
+    borderColor: '#DED6C8',
+    borderRadius: 8,
+    borderWidth: 1,
+    minHeight: 52,
+    overflow: 'hidden',
+  },
+  optionButtonSelected: {
+    borderColor: '#B0413E',
+  },
+  optionFill: {
+    backgroundColor: '#F8E7B1',
+    bottom: 0,
+    left: 0,
+    position: 'absolute',
+    top: 0,
+  },
+  optionContent: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 10,
+    justifyContent: 'space-between',
+    minHeight: 52,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  optionText: {
+    color: '#26231F',
+    flex: 1,
+    fontSize: 16,
+    fontWeight: '800',
+    letterSpacing: 0,
+    lineHeight: 22,
+  },
+  optionTextSelected: {
+    color: '#9F2E2B',
+  },
+  optionPercent: {
+    color: '#233D4D',
+    fontSize: 15,
+    fontWeight: '900',
+    letterSpacing: 0,
+  },
+  pollFooter: {
+    color: '#756F63',
+    fontSize: 13,
+    fontWeight: '700',
     letterSpacing: 0,
   },
 });

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -10,6 +10,13 @@ The app uses the existing Pollify backend auth endpoints:
 
 JWT sessions are stored with Expo SecureStore on device.
 
+Authenticated users land on a native trending poll feed backed by:
+
+- `GET /api/polls/trending`
+- `POST /api/votes`
+
+Vote responses update the selected poll, XP, streak, and total vote count in the mobile UI.
+
 ## Requirements
 
 - Node.js 20.19.4 or newer is recommended for the current Expo package set.

--- a/apps/mobile/src/context/AuthContext.tsx
+++ b/apps/mobile/src/context/AuthContext.tsx
@@ -11,6 +11,7 @@ import {
 import { authApi } from '../lib/api';
 import { clearSession, getStoredUser, getToken, saveSession } from '../lib/session';
 import type { AuthUser, LoginPayload, RegisterPayload } from '../types/auth';
+import type { VoteReward } from '../types/poll';
 
 interface AuthContextValue {
   user: AuthUser | null;
@@ -19,6 +20,7 @@ interface AuthContextValue {
   signIn: (payload: LoginPayload) => Promise<void>;
   signUp: (payload: RegisterPayload) => Promise<void>;
   signOut: () => Promise<void>;
+  applyVoteReward: (reward: VoteReward) => void;
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -78,6 +80,20 @@ export function AuthProvider({ children }: PropsWithChildren) {
     setUser(null);
   }, []);
 
+  const applyVoteReward = useCallback((reward: VoteReward) => {
+    setUser((current) =>
+      current
+        ? {
+            ...current,
+            xp: reward.xp,
+            streak: reward.streak,
+            totalVotes: reward.totalVotes,
+            lastVoteDate: reward.lastVoteDate,
+          }
+        : current,
+    );
+  }, []);
+
   const value = useMemo(
     () => ({
       user,
@@ -86,8 +102,9 @@ export function AuthProvider({ children }: PropsWithChildren) {
       signIn,
       signUp,
       signOut,
+      applyVoteReward,
     }),
-    [isLoading, signIn, signOut, signUp, user],
+    [applyVoteReward, isLoading, signIn, signOut, signUp, user],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -1,6 +1,7 @@
 import { API_BASE_URL } from '../config/api';
 import { getToken } from './session';
 import type { AuthResponse, AuthUser, LoginPayload, RegisterPayload } from '../types/auth';
+import type { ApiPoll, CastVoteResponse } from '../types/poll';
 
 interface ApiErrorShape {
   message?: string;
@@ -48,4 +49,16 @@ export const authApi = {
       body: JSON.stringify(payload),
     }),
   me: () => apiRequest<AuthUser>('/api/auth/me'),
+};
+
+export const pollsApi = {
+  getTrending: (count = 20) => apiRequest<ApiPoll[]>(`/api/polls/trending?count=${count}`),
+};
+
+export const votesApi = {
+  cast: (pollId: number, optionId: number) =>
+    apiRequest<CastVoteResponse>('/api/votes', {
+      method: 'POST',
+      body: JSON.stringify({ pollId, optionId }),
+    }),
 };

--- a/apps/mobile/src/types/poll.ts
+++ b/apps/mobile/src/types/poll.ts
@@ -1,0 +1,43 @@
+export interface ApiPollOption {
+  id: number;
+  pollId: number;
+  text: string;
+  voteCount: number;
+  votePercentage: number;
+}
+
+export interface ApiPoll {
+  id: number;
+  question: string;
+  description: string;
+  category: string;
+  isTrending: boolean;
+  isActive: boolean;
+  expiresAt: string;
+  createdAt: string;
+  totalVotes: number;
+  createdByUserId: number | null;
+  createdByUsername: string | null;
+  createdByDisplayName: string | null;
+  sourceType: string | null;
+  sourceUrl: string | null;
+  thumbnailUrl: string | null;
+  isAIGenerated: boolean;
+  options: ApiPollOption[];
+  hasVoted: boolean;
+  userVotedOptionId: number | null;
+}
+
+export interface VoteReward {
+  xp: number;
+  streak: number;
+  totalVotes: number;
+  xpAwarded: number;
+  streakAdvanced: boolean;
+  lastVoteDate: string | null;
+}
+
+export interface CastVoteResponse {
+  poll: ApiPoll;
+  reward: VoteReward;
+}


### PR DESCRIPTION
## Summary
- Adds mobile poll/vote API types and calls for trending polls and vote casting
- Replaces the signed-in placeholder with a native trending poll feed
- Supports pull-to-refresh, loading, empty, error, duplicate/expired vote messaging, and result bars
- Updates poll state and user XP/streak/total votes from vote reward responses
- Documents the mobile feed/vote backend endpoints

## Verification
- `./node_modules/.bin/tsc --noEmit` from `apps/mobile`
- `npx expo config --type public` from `apps/mobile`

Notes:
- Branch was created directly from `origin/main`.
- Expo continues to warn that local Node.js v20.18.0 is below the package set requirement of >=20.19.4.

Closes #70