### PR TITLE
Add mobile gamification screens

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
@@ -15,8 +15,11 @@ import {
 
 import { API_BASE_URL } from './src/config/api';
 import { AuthProvider, useAuth } from './src/context/AuthContext';
+import { usersApi } from './src/lib/api';
+import type { AuthUser } from './src/types/auth';
 
 type AuthMode = 'login' | 'register';
+type SignedInTab = 'home' | 'profile' | 'leaderboard';
 
 export default function App() {
   return (
@@ -224,8 +227,34 @@ function LabeledInput({
 
 function SignedInHome() {
   const { signOut, user } = useAuth();
+  const [activeTab, setActiveTab] = useState<SignedInTab>('home');
+  const [leaderboard, setLeaderboard] = useState<AuthUser[]>([]);
+  const [isLeaderboardLoading, setIsLeaderboardLoading] = useState(false);
+  const [leaderboardError, setLeaderboardError] = useState<string | null>(null);
+
+  const loadLeaderboard = useCallback(async () => {
+    setIsLeaderboardLoading(true);
+    setLeaderboardError(null);
+
+    try {
+      setLeaderboard(await usersApi.getLeaderboard(25));
+    } catch (err) {
+      setLeaderboardError(err instanceof Error ? err.message : 'Could not load leaderboard');
+    } finally {
+      setIsLeaderboardLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (activeTab === 'leaderboard' && leaderboard.length === 0) {
+      loadLeaderboard();
+    }
+  }, [activeTab, leaderboard.length, loadLeaderboard]);
 
   if (!user) return null;
+
+  const level = getLevel(user.xp ?? 0);
+  const progress = getLevelProgress(user.xp ?? 0);
 
   return (
     <ScrollView contentContainerStyle={styles.container}>
@@ -233,28 +262,59 @@ function SignedInHome() {
         <Text style={styles.eyebrow}>Pollify</Text>
         <Text style={styles.titleSmall}>Hi, {user.displayName}</Text>
         <Text style={styles.subtitle}>
-          Your mobile session is active and ready for poll feed integration.
+          Level {level} • {progress.current} / 500 XP to next level
         </Text>
       </View>
 
-      <View style={styles.profilePanel}>
-        <View>
-          <Text style={styles.profileName}>{user.displayName}</Text>
-          <Text style={styles.profileUsername}>@{user.username}</Text>
-        </View>
-        <View style={styles.metricGrid}>
-          <Metric label="XP" value={String(user.xp ?? 0)} />
-          <Metric label="Streak" value={String(user.streak ?? 0)} />
-          <Metric label="Votes" value={String(user.totalVotes ?? 0)} />
-          <Metric label="Polls" value={String(user.pollsCreated ?? 0)} />
-        </View>
+      <View style={styles.segment}>
+        <TabButton active={activeTab === 'home'} label="Home" onPress={() => setActiveTab('home')} />
+        <TabButton
+          active={activeTab === 'profile'}
+          label="Profile"
+          onPress={() => setActiveTab('profile')}
+        />
+        <TabButton
+          active={activeTab === 'leaderboard'}
+          label="Ranks"
+          onPress={() => setActiveTab('leaderboard')}
+        />
       </View>
 
+      {activeTab === 'home' && (
+        <>
+          <View style={styles.progressPanel}>
+            <View style={styles.progressHeader}>
+              <Text style={styles.panelTitle}>Today's progress</Text>
+              <Text style={styles.levelPill}>Level {level}</Text>
+            </View>
+            <View style={styles.progressTrack}>
+              <View style={[styles.progressFill, { width: `${progress.percent}%` }]} />
+            </View>
+            <Text style={styles.progressCopy}>
+              Keep voting to grow your streak and climb the leaderboard.
+            </Text>
+          </View>
+
+          <UserStatsPanel user={user} />
+        </>
+      )}
+
+      {activeTab === 'profile' && <ProfilePanel level={level} user={user} />}
+
+      {activeTab === 'leaderboard' && (
+        <LeaderboardPanel
+          currentUserId={user.id}
+          error={leaderboardError}
+          isLoading={isLeaderboardLoading}
+          onRefresh={loadLeaderboard}
+          users={leaderboard}
+        />
+      )}
+
       <View style={styles.actionPanel}>
-        <Text style={styles.actionTitle}>Session stored securely</Text>
+        <Text style={styles.actionTitle}>Gamified mobile profile</Text>
         <Text style={styles.actionCopy}>
-          The JWT is saved with Expo SecureStore and refreshed from `/api/auth/me`
-          when the app starts.
+          XP, streak, level, profile stats, and rankings are driven by backend user data.
         </Text>
         <Pressable onPress={signOut} style={styles.secondaryButton}>
           <Text style={styles.secondaryButtonText}>Logout</Text>
@@ -262,6 +322,156 @@ function SignedInHome() {
       </View>
     </ScrollView>
   );
+}
+
+function TabButton({
+  active,
+  label,
+  onPress,
+}: {
+  active: boolean;
+  label: string;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={[styles.segmentButton, active && styles.segmentButtonActive]}
+    >
+      <Text style={[styles.segmentText, active && styles.segmentTextActive]}>{label}</Text>
+    </Pressable>
+  );
+}
+
+function UserStatsPanel({ user }: { user: AuthUser }) {
+  return (
+    <View style={styles.profilePanel}>
+      <View>
+        <Text style={styles.profileName}>{user.displayName}</Text>
+        <Text style={styles.profileUsername}>@{user.username}</Text>
+      </View>
+      <View style={styles.metricGrid}>
+        <Metric label="XP" value={String(user.xp ?? 0)} />
+        <Metric label="Streak" value={String(user.streak ?? 0)} />
+        <Metric label="Votes" value={String(user.totalVotes ?? 0)} />
+        <Metric label="Polls" value={String(user.pollsCreated ?? 0)} />
+      </View>
+    </View>
+  );
+}
+
+function ProfilePanel({ level, user }: { level: number; user: AuthUser }) {
+  return (
+    <View style={styles.profilePanel}>
+      <View>
+        <Text style={styles.profileName}>{user.displayName}</Text>
+        <Text style={styles.profileUsername}>@{user.username}</Text>
+      </View>
+      <View style={styles.metricGrid}>
+        <Metric label="Level" value={String(level)} />
+        <Metric label="XP" value={String(user.xp ?? 0)} />
+        <Metric label="Streak" value={String(user.streak ?? 0)} />
+        <Metric label="Votes" value={String(user.totalVotes ?? 0)} />
+        <Metric label="Polls" value={String(user.pollsCreated ?? 0)} />
+        <Metric label="Joined" value={formatMonth(user.createdAt)} />
+      </View>
+    </View>
+  );
+}
+
+function LeaderboardPanel({
+  currentUserId,
+  error,
+  isLoading,
+  onRefresh,
+  users,
+}: {
+  currentUserId: number;
+  error: string | null;
+  isLoading: boolean;
+  onRefresh: () => void;
+  users: AuthUser[];
+}) {
+  return (
+    <View style={styles.profilePanel}>
+      <View style={styles.progressHeader}>
+        <Text style={styles.panelTitle}>Leaderboard</Text>
+        <Pressable onPress={onRefresh} style={styles.smallButton}>
+          <Text style={styles.smallButtonText}>Refresh</Text>
+        </Pressable>
+      </View>
+
+      {isLoading ? (
+        <View style={styles.inlineState}>
+          <ActivityIndicator color="#B0413E" />
+          <Text style={styles.inlineStateText}>Loading real rankings</Text>
+        </View>
+      ) : error ? (
+        <Text style={styles.errorText}>{error}</Text>
+      ) : users.length === 0 ? (
+        <View style={styles.inlineState}>
+          <Text style={styles.inlineStateText}>No ranked users yet.</Text>
+        </View>
+      ) : (
+        users.map((rankedUser, index) => (
+          <LeaderboardRow
+            currentUserId={currentUserId}
+            key={rankedUser.id}
+            rank={index + 1}
+            user={rankedUser}
+          />
+        ))
+      )}
+    </View>
+  );
+}
+
+function LeaderboardRow({
+  currentUserId,
+  rank,
+  user,
+}: {
+  currentUserId: number;
+  rank: number;
+  user: AuthUser;
+}) {
+  const isCurrentUser = user.id === currentUserId;
+
+  return (
+    <View style={[styles.leaderboardRow, isCurrentUser && styles.leaderboardRowActive]}>
+      <Text style={styles.rankText}>#{rank}</Text>
+      <View style={styles.leaderboardIdentity}>
+        <Text style={styles.leaderboardName}>{user.displayName}</Text>
+        <Text style={styles.leaderboardUsername}>@{user.username}</Text>
+      </View>
+      <View style={styles.leaderboardScore}>
+        <Text style={styles.leaderboardXp}>{user.xp ?? 0}</Text>
+        <Text style={styles.leaderboardLabel}>XP</Text>
+      </View>
+    </View>
+  );
+}
+
+function getLevel(xp: number) {
+  return Math.floor(xp / 500) + 1;
+}
+
+function getLevelProgress(xp: number) {
+  const current = xp % 500;
+  return {
+    current,
+    percent: Math.min(100, Math.round((current / 500) * 100)),
+  };
+}
+
+function formatMonth(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'New';
+
+  return date.toLocaleDateString('en-IN', {
+    month: 'short',
+    year: '2-digit',
+  });
 }
 
 function Metric({ label, value }: { label: string; value: string }) {
@@ -470,6 +680,128 @@ const styles = StyleSheet.create({
     fontWeight: '800',
     letterSpacing: 0,
     marginTop: 2,
+    textTransform: 'uppercase',
+  },
+  progressPanel: {
+    backgroundColor: '#FFFFFF',
+    borderColor: '#E6E0D4',
+    borderRadius: 8,
+    borderWidth: 1,
+    gap: 14,
+    padding: 18,
+  },
+  progressHeader: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  levelPill: {
+    backgroundColor: '#F4D35E',
+    borderRadius: 8,
+    color: '#1F2B32',
+    fontSize: 13,
+    fontWeight: '900',
+    letterSpacing: 0,
+    overflow: 'hidden',
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    textTransform: 'uppercase',
+  },
+  progressTrack: {
+    backgroundColor: '#EEE8DC',
+    borderRadius: 8,
+    height: 12,
+    overflow: 'hidden',
+  },
+  progressFill: {
+    backgroundColor: '#B0413E',
+    bottom: 0,
+    left: 0,
+    position: 'absolute',
+    top: 0,
+  },
+  progressCopy: {
+    color: '#54514A',
+    fontSize: 15,
+    lineHeight: 22,
+  },
+  smallButton: {
+    backgroundColor: '#F7F5EF',
+    borderColor: '#E6E0D4',
+    borderRadius: 8,
+    borderWidth: 1,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  smallButtonText: {
+    color: '#233D4D',
+    fontSize: 13,
+    fontWeight: '900',
+    letterSpacing: 0,
+  },
+  inlineState: {
+    alignItems: 'center',
+    gap: 10,
+    padding: 18,
+  },
+  inlineStateText: {
+    color: '#54514A',
+    fontSize: 15,
+    fontWeight: '700',
+    letterSpacing: 0,
+  },
+  leaderboardRow: {
+    alignItems: 'center',
+    backgroundColor: '#F9F7F2',
+    borderColor: '#E6E0D4',
+    borderRadius: 8,
+    borderWidth: 1,
+    flexDirection: 'row',
+    gap: 12,
+    padding: 12,
+  },
+  leaderboardRowActive: {
+    backgroundColor: '#FFF6D8',
+    borderColor: '#F4D35E',
+  },
+  rankText: {
+    color: '#B0413E',
+    fontSize: 16,
+    fontWeight: '900',
+    letterSpacing: 0,
+    minWidth: 38,
+  },
+  leaderboardIdentity: {
+    flex: 1,
+  },
+  leaderboardName: {
+    color: '#222222',
+    fontSize: 16,
+    fontWeight: '900',
+    letterSpacing: 0,
+  },
+  leaderboardUsername: {
+    color: '#756F63',
+    fontSize: 13,
+    fontWeight: '700',
+    letterSpacing: 0,
+    marginTop: 2,
+  },
+  leaderboardScore: {
+    alignItems: 'flex-end',
+  },
+  leaderboardXp: {
+    color: '#233D4D',
+    fontSize: 18,
+    fontWeight: '900',
+    letterSpacing: 0,
+  },
+  leaderboardLabel: {
+    color: '#756F63',
+    fontSize: 11,
+    fontWeight: '900',
+    letterSpacing: 0,
     textTransform: 'uppercase',
   },
   actionPanel: {

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -10,6 +10,12 @@ The app uses the existing Pollify backend auth endpoints:
 
 JWT sessions are stored with Expo SecureStore on device.
 
+Signed-in users can switch between mobile gamification surfaces:
+
+- Home: current XP, streak, and level progress.
+- Profile: votes, polls created, XP, streak, level, and joined date.
+- Ranks: real backend leaderboard data from `GET /api/users/leaderboard`.
+
 ## Requirements
 
 - Node.js 20.19.4 or newer is recommended for the current Expo package set.

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -49,3 +49,7 @@ export const authApi = {
     }),
   me: () => apiRequest<AuthUser>('/api/auth/me'),
 };
+
+export const usersApi = {
+  getLeaderboard: (count = 20) => apiRequest<AuthUser[]>(`/api/users/leaderboard?count=${count}`),
+};


### PR DESCRIPTION
## Summary
- Adds signed-in mobile Home/Profile/Ranks tabs for gamification surfaces
- Shows current XP, streak, level progress, votes, polls created, and joined date from authenticated user data
- Adds a real leaderboard API call to `GET /api/users/leaderboard` with loading, empty, error, and refresh states
- Highlights the current user in the leaderboard without mock rankings
- Documents the mobile gamification surfaces in the mobile README

## Verification
- `./node_modules/.bin/tsc --noEmit` from `apps/mobile`
- `npx expo config --type public` from `apps/mobile`

Notes:
- Branch was created directly from `origin/main`.
- This PR intentionally does not depend on the unmerged #75 feed/voting branch; reward feedback can be connected to the feed once #70 lands.
- Expo continues to warn that local Node.js v20.18.0 is below the package set requirement of >=20.19.4.

Closes #71