### PR TITLE
Add poll share buttons

### DIFF
--- a/Frontend/.env.local.example
+++ b/Frontend/.env.local.example
@@ -3,6 +3,9 @@
 # URL of your running ASP.NET Core backend
 NEXT_PUBLIC_API_URL=http://localhost:5177
 
+# Public web app URL used for share links
+NEXT_PUBLIC_BASE_URL=http://localhost:3000
+
 # Google OAuth Client ID (from Google Cloud Console)
 # https://console.cloud.google.com/ → APIs & Services → Credentials
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=your_google_client_id.apps.googleusercontent.com

--- a/Frontend/components/poll-detail/poll-detail-card.tsx
+++ b/Frontend/components/poll-detail/poll-detail-card.tsx
@@ -15,6 +15,7 @@ import {
   Zap,
 } from "lucide-react"
 import { motion } from "framer-motion"
+import { ShareButton } from "@/components/share-button"
 import { Button } from "@/components/ui/button"
 import { useAuth } from "@/contexts/auth-context"
 import { pollsApi, votesApi, type ApiPoll, type ApiPollOption } from "@/lib/api"
@@ -221,18 +222,26 @@ export function PollDetailCard({ pollId }: PollDetailCardProps) {
 
           <div className="absolute inset-0 bg-gradient-to-t from-card via-card/20 to-transparent" />
 
-          <div className="absolute left-4 top-4 flex flex-wrap gap-2">
-            {poll.isTrending && (
-              <span className="rounded-full bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground">
-                Trending
-              </span>
-            )}
-            {poll.isAIGenerated && (
-              <span className="flex items-center gap-1.5 rounded-full bg-violet-500/15 px-3 py-1.5 text-xs font-medium text-violet-400 ring-1 ring-violet-500/30">
-                <Sparkles className="h-3 w-3" />
-                AI Poll
-              </span>
-            )}
+          <div className="absolute left-4 right-4 top-4 flex items-start justify-between gap-3">
+            <div className="flex flex-wrap gap-2">
+              {poll.isTrending && (
+                <span className="rounded-full bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground">
+                  Trending
+                </span>
+              )}
+              {poll.isAIGenerated && (
+                <span className="flex items-center gap-1.5 rounded-full bg-violet-500/15 px-3 py-1.5 text-xs font-medium text-violet-400 ring-1 ring-violet-500/30">
+                  <Sparkles className="h-3 w-3" />
+                  AI Poll
+                </span>
+              )}
+            </div>
+
+            <ShareButton
+              className="bg-background/85 shadow-lg backdrop-blur-sm hover:bg-background"
+              pollId={poll.id}
+              title={poll.question}
+            />
           </div>
 
           <div

--- a/Frontend/components/poll-feed/poll-card.tsx
+++ b/Frontend/components/poll-feed/poll-card.tsx
@@ -16,6 +16,7 @@ import {
   CheckCircle2,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
+import { ShareButton } from "@/components/share-button"
 import { Poll, SOURCE_COLORS, SOURCE_LABELS } from "@/lib/poll-data"
 import {
   Tooltip,
@@ -223,7 +224,7 @@ export function PollCard({ poll, onVote, isActive }: PollCardProps) {
           )}
 
           {/* ── Top Badges ───────────────────────────────────────────────── */}
-          <div className="absolute left-4 right-4 top-4 flex items-start justify-between">
+          <div className="absolute left-4 right-4 top-4 flex items-start justify-between gap-3">
             <div className="flex flex-col gap-1.5">
               {poll.trending && (
                 <motion.div
@@ -249,18 +250,26 @@ export function PollCard({ poll, onVote, isActive }: PollCardProps) {
               )}
             </div>
 
-            {/* XP Reward — hidden on voted cards */}
-            {!hasVoted && (
-              <motion.div
-                className="flex items-center gap-1.5 rounded-full bg-amber-500 px-3 py-1.5 text-amber-950 shadow-lg"
-                initial={{ scale: 0, y: -20 }}
-                animate={{ scale: 1, y: 0 }}
-                transition={{ delay: 0.3, type: "spring" }}
-              >
-                <Zap className="h-3.5 w-3.5 fill-current" />
-                <span className="text-xs font-bold">+{poll.xpReward} XP</span>
-              </motion.div>
-            )}
+            <div className="flex flex-col items-end gap-2">
+              <ShareButton
+                className="bg-background/85 shadow-lg backdrop-blur-sm hover:bg-background"
+                pollId={poll.id}
+                title={poll.question}
+              />
+
+              {/* XP Reward — hidden on voted cards */}
+              {!hasVoted && (
+                <motion.div
+                  className="flex items-center gap-1.5 rounded-full bg-amber-500 px-3 py-1.5 text-amber-950 shadow-lg"
+                  initial={{ scale: 0, y: -20 }}
+                  animate={{ scale: 1, y: 0 }}
+                  transition={{ delay: 0.3, type: "spring" }}
+                >
+                  <Zap className="h-3.5 w-3.5 fill-current" />
+                  <span className="text-xs font-bold">+{poll.xpReward} XP</span>
+                </motion.div>
+              )}
+            </div>
           </div>
 
           {/* ── Source Badge ─────────────────────────────────────────────── */}

--- a/Frontend/components/providers.tsx
+++ b/Frontend/components/providers.tsx
@@ -3,6 +3,7 @@
 import { GoogleOAuthProvider } from "@react-oauth/google"
 import { AuthProvider } from "@/contexts/auth-context"
 import { ThemeProvider } from "@/components/theme-provider"
+import { Toaster } from "@/components/ui/toaster"
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
@@ -17,6 +18,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
           disableTransitionOnChange
         >
           {children}
+          <Toaster />
         </ThemeProvider>
       </AuthProvider>
     </GoogleOAuthProvider>

--- a/Frontend/components/share-button.tsx
+++ b/Frontend/components/share-button.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import { Share2 } from "lucide-react"
+import type { MouseEvent } from "react"
+import { Button } from "@/components/ui/button"
+import { toast } from "@/hooks/use-toast"
+import { cn } from "@/lib/utils"
+
+interface ShareButtonProps {
+  pollId: number | string
+  title: string
+  className?: string
+  variant?: "default" | "secondary" | "ghost" | "outline"
+}
+
+function appBaseUrl() {
+  const configured = process.env.NEXT_PUBLIC_BASE_URL
+  if (configured) return configured.replace(/\/+$/, "")
+
+  if (typeof window !== "undefined") {
+    return window.location.origin
+  }
+
+  return ""
+}
+
+function showShareToast(title: "Link copied!" | "Shared!") {
+  const { dismiss } = toast({ title })
+  window.setTimeout(dismiss, 2000)
+}
+
+export function ShareButton({
+  className,
+  pollId,
+  title,
+  variant = "secondary",
+}: ShareButtonProps) {
+  async function sharePoll(event: MouseEvent<HTMLButtonElement>) {
+    event.stopPropagation()
+
+    const url = `${appBaseUrl()}/polls/${pollId}`
+    const shareData = {
+      title,
+      text: title,
+      url,
+    }
+
+    try {
+      if (navigator.share && navigator.canShare?.(shareData) !== false) {
+        await navigator.share(shareData)
+        showShareToast("Shared!")
+        return
+      }
+
+      await navigator.clipboard.writeText(url)
+      showShareToast("Link copied!")
+    } catch (error) {
+      if ((error as DOMException).name === "AbortError") return
+
+      await navigator.clipboard.writeText(url)
+      showShareToast("Link copied!")
+    }
+  }
+
+  return (
+    <Button
+      aria-label="Share poll"
+      className={cn("gap-2", className)}
+      onClick={sharePoll}
+      onPointerDown={(event) => event.stopPropagation()}
+      size="sm"
+      type="button"
+      variant={variant}
+    >
+      <Share2 className="h-4 w-4" />
+      <span className="sr-only sm:not-sr-only">Share</span>
+    </Button>
+  )
+}


### PR DESCRIPTION
## Summary
- add a reusable poll share button that uses native Web Share when available and falls back to copying the poll detail URL
- show 2-second success toasts for shared/copied states
- place share controls on feed cards and poll detail pages, and document NEXT_PUBLIC_BASE_URL

## Verification
- ./node_modules/.bin/tsc --noEmit
- npm run build
- npm run lint *(fails: eslint is not installed in Frontend package)*

Closes #38