### PR TITLE
Add category filtering to poll feed

### DIFF
--- a/Backend/BackendAPI/Controllers/PollsController.cs
+++ b/Backend/BackendAPI/Controllers/PollsController.cs
@@ -27,17 +27,19 @@ namespace BackendAPI.Controllers
 
         // GET /api/polls
         [HttpGet]
-        public async Task<IActionResult> GetAll()
+        public async Task<IActionResult> GetAll([FromQuery] string? category = null)
         {
-            var polls = await _pollsRepo.GetAllAsync(CurrentUserId());
+            var polls = await _pollsRepo.GetAllAsync(CurrentUserId(), category);
             return Ok(polls);
         }
 
         // GET /api/polls/trending
         [HttpGet("trending")]
-        public async Task<IActionResult> GetTrending([FromQuery] int count = 10)
+        public async Task<IActionResult> GetTrending(
+            [FromQuery] int count = 10,
+            [FromQuery] string? category = null)
         {
-            var polls = await _pollsRepo.GetTrendingAsync(count, CurrentUserId());
+            var polls = await _pollsRepo.GetTrendingAsync(count, CurrentUserId(), category);
             return Ok(polls);
         }
 

--- a/Backend/BackendAPI/Interfaces/IPollsRepository.cs
+++ b/Backend/BackendAPI/Interfaces/IPollsRepository.cs
@@ -5,9 +5,9 @@ namespace BackendAPI.Interfaces
     public interface IPollsRepository
     {
         /// <param name="userId">When provided, HasVoted / UserVotedOptionId are populated.</param>
-        Task<IEnumerable<Poll>> GetAllAsync(long? userId = null);
+        Task<IEnumerable<Poll>> GetAllAsync(long? userId = null, string? category = null);
         Task<Poll?> GetByIdAsync(long id, long? userId = null);
-        Task<IEnumerable<Poll>> GetTrendingAsync(int count = 10, long? userId = null);
+        Task<IEnumerable<Poll>> GetTrendingAsync(int count = 10, long? userId = null, string? category = null);
         Task<IEnumerable<Poll>> GetRecentAsync(int count = 10);
         Task<long> CreateAsync(CreatePollRequest request, long? createdByUserId = null);
         Task<bool> DeleteAsync(long id);

--- a/Backend/BackendAPI/Repository/PollsRepository.cs
+++ b/Backend/BackendAPI/Repository/PollsRepository.cs
@@ -50,10 +50,13 @@ namespace BackendAPI.Repository
 
         // ── GetAll ────────────────────────────────────────────────────────────
 
-        public async Task<IEnumerable<Poll>> GetAllAsync(long? userId = null)
+        public async Task<IEnumerable<Poll>> GetAllAsync(long? userId = null, string? category = null)
         {
             using var conn = _context.CreateConnection();
             var pollDict   = new Dictionary<long, Poll>();
+            var normalizedCategory = string.IsNullOrWhiteSpace(category)
+                ? null
+                : category.Trim();
 
             await conn.QueryAsync<Poll, PollOption, Poll>(
                 @"SELECT p.*, u.Username AS CreatedByUsername, u.DisplayName AS CreatedByDisplayName, o.*
@@ -61,6 +64,7 @@ namespace BackendAPI.Repository
                   LEFT JOIN Users u ON u.Id = p.CreatedByUserId
                   LEFT JOIN PollOptions o ON o.PollId = p.Id
                   WHERE p.IsActive = 1
+                    AND (@Category IS NULL OR LOWER(p.Category) = LOWER(@Category))
                   ORDER BY p.CreatedAt DESC",
                 (poll, option) =>
                 {
@@ -73,6 +77,7 @@ namespace BackendAPI.Repository
                     if (option != null) existing.Options.Add(option);
                     return existing;
                 },
+                new { Category = normalizedCategory },
                 splitOn: "Id"
             );
 
@@ -114,10 +119,13 @@ namespace BackendAPI.Repository
 
         // ── GetTrending ───────────────────────────────────────────────────────
 
-        public async Task<IEnumerable<Poll>> GetTrendingAsync(int count = 10, long? userId = null)
+        public async Task<IEnumerable<Poll>> GetTrendingAsync(int count = 10, long? userId = null, string? category = null)
         {
             using var conn = _context.CreateConnection();
             var pollDict   = new Dictionary<long, Poll>();
+            var normalizedCategory = string.IsNullOrWhiteSpace(category)
+                ? null
+                : category.Trim();
 
             // US-09: order by TotalVotes DESC directly
             await conn.QueryAsync<Poll, PollOption, Poll>(
@@ -126,6 +134,7 @@ namespace BackendAPI.Repository
                   LEFT JOIN Users u ON u.Id = p.CreatedByUserId
                   LEFT JOIN PollOptions o ON o.PollId = p.Id
                   WHERE p.IsActive = 1
+                    AND (@Category IS NULL OR LOWER(p.Category) = LOWER(@Category))
                   ORDER BY p.TotalVotes DESC, p.CreatedAt DESC",
                 (poll, option) =>
                 {
@@ -138,7 +147,7 @@ namespace BackendAPI.Repository
                     if (option != null) existing.Options.Add(option);
                     return existing;
                 },
-                new { Count = count },
+                new { Count = count, Category = normalizedCategory },
                 splitOn: "Id"
             );
 

--- a/Frontend/components/poll-feed/category-chips.tsx
+++ b/Frontend/components/poll-feed/category-chips.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import { motion } from "framer-motion"
+import { cn } from "@/lib/utils"
+
+export const FEED_CATEGORIES = [
+  "All",
+  "Technology",
+  "Society",
+  "Work",
+  "Environment",
+  "Culture",
+  "Sports",
+  "Health",
+  "Politics",
+] as const
+
+interface CategoryChipsProps {
+  selected: string
+  onSelect: (category: string) => void
+}
+
+export function CategoryChips({ selected, onSelect }: CategoryChipsProps) {
+  const chipRefs = useRef(new Map<string, HTMLButtonElement>())
+
+  useEffect(() => {
+    chipRefs.current
+      .get(selected)
+      ?.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "center" })
+  }, [selected])
+
+  return (
+    <div className="border-y border-border/60 bg-background/80 py-2 backdrop-blur-sm">
+      <div className="flex gap-2 overflow-x-auto scroll-smooth px-4 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        {FEED_CATEGORIES.map((category) => {
+          const active = selected === category
+
+          return (
+            <motion.button
+              animate={{ scale: active ? 1.03 : 1 }}
+              className={cn(
+                "relative h-9 flex-shrink-0 rounded-full px-4 text-sm font-semibold transition-colors",
+                active
+                  ? "bg-primary text-primary-foreground shadow-sm"
+                  : "bg-secondary text-secondary-foreground hover:bg-secondary/80"
+              )}
+              key={category}
+              ref={(node) => {
+                if (node) chipRefs.current.set(category, node)
+                else chipRefs.current.delete(category)
+              }}
+              onClick={() => onSelect(category)}
+              type="button"
+              whileTap={{ scale: 0.97 }}
+            >
+              {category}
+            </motion.button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/Frontend/components/poll-feed/index.tsx
+++ b/Frontend/components/poll-feed/index.tsx
@@ -1,8 +1,9 @@
 "use client"
 
-import { useState, useCallback } from "react"
+import { useState, useCallback, useEffect } from "react"
 import { motion, AnimatePresence } from "framer-motion"
 import { RefreshCw, Sparkles, AlertCircle, Loader2 } from "lucide-react"
+import { CategoryChips, FEED_CATEGORIES } from "./category-chips"
 import { PollCard } from "./poll-card"
 import { VoteFeedback } from "./vote-feedback"
 import { StreakCounter } from "./streak-counter"
@@ -12,8 +13,9 @@ import { usePolls } from "@/hooks/use-polls"
 import type { Poll } from "@/lib/poll-data"
 
 export function PollFeed() {
-  const { polls, loading, error, castVote, loadMore, hasMore } = usePolls()
-
+  const [selectedCategory, setSelectedCategory] = useState("All")
+  const feedCategory = selectedCategory === "All" ? undefined : selectedCategory
+  const { polls, loading, error, castVote, loadMore, hasMore } = usePolls(feedCategory)
   const [currentIndex, setCurrentIndex]   = useState(0)
   const [streak, setStreak]               = useState(0)
   const [totalXp, setTotalXp]             = useState(1250)
@@ -22,6 +24,20 @@ export function PollFeed() {
 
   const currentPoll: Poll | undefined = polls[currentIndex]
   const hasMorePolls = currentIndex < polls.length
+
+  useEffect(() => {
+    const saved = window.localStorage.getItem("poll-feed-category")
+    if (saved && FEED_CATEGORIES.includes(saved as (typeof FEED_CATEGORIES)[number])) {
+      setSelectedCategory(saved)
+    }
+  }, [])
+
+  const handleCategorySelect = useCallback((category: string) => {
+    setSelectedCategory(category)
+    setCurrentIndex(0)
+    setCurrentVote(null)
+    window.localStorage.setItem("poll-feed-category", category)
+  }, [])
 
   const handleVote = useCallback(
     async (vote: "yes" | "no") => {
@@ -64,9 +80,12 @@ export function PollFeed() {
   // ── Loading state ─────────────────────────────────────────────────────────
   if (loading) {
     return (
-      <div className="flex h-full flex-col items-center justify-center gap-4">
-        <Loader2 className="h-10 w-10 animate-spin text-primary" />
-        <p className="text-sm text-muted-foreground">Loading polls...</p>
+      <div className="relative flex h-full flex-col">
+        <CategoryChips selected={selectedCategory} onSelect={handleCategorySelect} />
+        <div className="flex flex-1 flex-col items-center justify-center gap-4">
+          <Loader2 className="h-10 w-10 animate-spin text-primary" />
+          <p className="text-sm text-muted-foreground">Loading polls...</p>
+        </div>
       </div>
     )
   }
@@ -74,20 +93,25 @@ export function PollFeed() {
   // ── Error state ───────────────────────────────────────────────────────────
   if (error) {
     return (
-      <div className="flex h-full flex-col items-center justify-center gap-4 px-8 text-center">
-        <AlertCircle className="h-10 w-10 text-destructive" />
-        <p className="font-semibold text-foreground">Could not load polls</p>
-        <p className="text-sm text-muted-foreground">{error}</p>
-        <Button variant="outline" onClick={() => window.location.reload()} className="gap-2">
-          <RefreshCw className="h-4 w-4" />
-          Retry
-        </Button>
+      <div className="relative flex h-full flex-col">
+        <CategoryChips selected={selectedCategory} onSelect={handleCategorySelect} />
+        <div className="flex flex-1 flex-col items-center justify-center gap-4 px-8 text-center">
+          <AlertCircle className="h-10 w-10 text-destructive" />
+          <p className="font-semibold text-foreground">Could not load polls</p>
+          <p className="text-sm text-muted-foreground">{error}</p>
+          <Button variant="outline" onClick={() => window.location.reload()} className="gap-2">
+            <RefreshCw className="h-4 w-4" />
+            Retry
+          </Button>
+        </div>
       </div>
     )
   }
 
   return (
     <div className="relative flex h-full flex-col">
+      <CategoryChips selected={selectedCategory} onSelect={handleCategorySelect} />
+
       {/* Header Stats */}
       <motion.div
         className="flex items-center justify-between px-4 py-3"

--- a/Frontend/hooks/use-polls.ts
+++ b/Frontend/hooks/use-polls.ts
@@ -15,7 +15,7 @@ interface UsePollsResult {
 
 const PAGE_SIZE = 20
 
-export function usePolls(): UsePollsResult {
+export function usePolls(category?: string): UsePollsResult {
   const [polls, setPolls]   = useState<Poll[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError]   = useState<string | null>(null)
@@ -25,7 +25,12 @@ export function usePolls(): UsePollsResult {
   useEffect(() => {
     let cancelled = false
 
-    pollsApi.getTrending(PAGE_SIZE)
+    setLoading(true)
+    setError(null)
+    setPolls([])
+    setHasMore(true)
+
+    pollsApi.getTrending(PAGE_SIZE, category)
       .then((data) => {
         if (cancelled) return
         // US-19: filter out polls the user has already voted on
@@ -42,12 +47,12 @@ export function usePolls(): UsePollsResult {
       })
 
     return () => { cancelled = true }
-  }, [])
+  }, [category])
 
   // Load more (fetch all and append new ones)
   const loadMore = useCallback(async () => {
     try {
-      const data = await pollsApi.getAll()
+      const data = await pollsApi.getAll(category)
       const existing = new Set(polls.map((p) => p.id))
       // US-19: exclude already-voted and already-loaded polls
       const fresh = data
@@ -58,7 +63,7 @@ export function usePolls(): UsePollsResult {
     } catch (err) {
       setError((err as Error).message)
     }
-  }, [polls])
+  }, [category, polls])
 
   // Cast a vote — optimistically update percentages
   const castVote = useCallback(async (pollId: string, optionId: number) => {

--- a/Frontend/lib/api.ts
+++ b/Frontend/lib/api.ts
@@ -98,13 +98,23 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 
 // ── Poll endpoints ────────────────────────────────────────────────────────────
 
+function categoryQuery(category?: string) {
+  return category ? `category=${encodeURIComponent(category)}` : ""
+}
+
 export const pollsApi = {
   /** Fetch trending polls for the feed. Includes hasVoted when authenticated. */
-  getTrending: (count = 20) =>
-    request<ApiPoll[]>(`/api/polls/trending?count=${count}`),
+  getTrending: (count = 20, category?: string) => {
+    const query = new URLSearchParams({ count: String(count) })
+    if (category) query.set("category", category)
+    return request<ApiPoll[]>(`/api/polls/trending?${query.toString()}`)
+  },
 
   /** Fetch all polls. Includes hasVoted when authenticated. */
-  getAll: () => request<ApiPoll[]>("/api/polls"),
+  getAll: (category?: string) => {
+    const query = categoryQuery(category)
+    return request<ApiPoll[]>(`/api/polls${query ? `?${query}` : ""}`)
+  },
 
   /** Fetch one poll. Includes hasVoted when authenticated. */
   getById: (id: number | string) => request<ApiPoll>(`/api/polls/${id}`),


### PR DESCRIPTION
## Summary
- add optional category filtering to `/api/polls` and `/api/polls/trending`
- pass the selected category through the frontend polls API and `usePolls`
- add a horizontally scrollable category chip row that persists the selected category in localStorage and resets the feed index on selection

## Verification
- dotnet build *(passes with existing nullable warning in AuthRepository.cs)*
- ./node_modules/.bin/tsc --noEmit
- npm run build
- npm run lint *(fails: eslint is not installed in Frontend package)*

Closes #39