### PR TITLE
Add poll search overlay

### DIFF
--- a/Backend/BackendAPI/Controllers/PollsController.cs
+++ b/Backend/BackendAPI/Controllers/PollsController.cs
@@ -43,6 +43,19 @@ namespace BackendAPI.Controllers
             return Ok(polls);
         }
 
+        // GET /api/polls/search?q=keyword
+        [HttpGet("search")]
+        public async Task<IActionResult> Search(
+            [FromQuery] string? q,
+            [FromQuery] string? category = null)
+        {
+            if (string.IsNullOrWhiteSpace(q))
+                return BadRequest(new { message = "Search query is required." });
+
+            var polls = await _pollsRepo.SearchAsync(q, category, CurrentUserId());
+            return Ok(polls);
+        }
+
         // GET /api/polls/{id}
         [HttpGet("{id}")]
         public async Task<IActionResult> GetById(long id)

--- a/Backend/BackendAPI/Interfaces/IPollsRepository.cs
+++ b/Backend/BackendAPI/Interfaces/IPollsRepository.cs
@@ -8,6 +8,7 @@ namespace BackendAPI.Interfaces
         Task<IEnumerable<Poll>> GetAllAsync(long? userId = null, string? category = null);
         Task<Poll?> GetByIdAsync(long id, long? userId = null);
         Task<IEnumerable<Poll>> GetTrendingAsync(int count = 10, long? userId = null, string? category = null);
+        Task<IEnumerable<Poll>> SearchAsync(string query, string? category = null, long? userId = null);
         Task<IEnumerable<Poll>> GetRecentAsync(int count = 10);
         Task<long> CreateAsync(CreatePollRequest request, long? createdByUserId = null);
         Task<bool> DeleteAsync(long id);

--- a/Backend/BackendAPI/Repository/PollsRepository.cs
+++ b/Backend/BackendAPI/Repository/PollsRepository.cs
@@ -157,6 +157,47 @@ namespace BackendAPI.Repository
 
         // ── GetRecent ─────────────────────────────────────────────────────────
 
+        public async Task<IEnumerable<Poll>> SearchAsync(string query, string? category = null, long? userId = null)
+        {
+            using var conn = _context.CreateConnection();
+            var pollDict   = new Dictionary<long, Poll>();
+            var normalizedCategory = string.IsNullOrWhiteSpace(category)
+                ? null
+                : category.Trim();
+
+            await conn.QueryAsync<Poll, PollOption, Poll>(
+                @"WITH SearchPolls AS (
+                    SELECT TOP (50) p.*
+                    FROM Polls p
+                    WHERE p.IsActive = 1
+                      AND p.Question LIKE @Search
+                      AND (@Category IS NULL OR LOWER(p.Category) = LOWER(@Category))
+                    ORDER BY p.TotalVotes DESC, p.CreatedAt DESC
+                  )
+                  SELECT sp.*, u.Username AS CreatedByUsername, u.DisplayName AS CreatedByDisplayName, o.*
+                  FROM SearchPolls sp
+                  LEFT JOIN Users u ON u.Id = sp.CreatedByUserId
+                  LEFT JOIN PollOptions o ON o.PollId = sp.Id
+                  ORDER BY sp.TotalVotes DESC, sp.CreatedAt DESC",
+                (poll, option) =>
+                {
+                    if (!pollDict.TryGetValue(poll.Id, out var existing))
+                    {
+                        existing = poll;
+                        existing.Options = new List<PollOption>();
+                        pollDict[poll.Id] = existing;
+                    }
+                    if (option != null) existing.Options.Add(option);
+                    return existing;
+                },
+                new { Search = $"%{query.Trim()}%", Category = normalizedCategory },
+                splitOn: "Id"
+            );
+
+            var userVotes = await GetUserVotesAsync(userId);
+            return ApplyVoteState(pollDict.Values, userVotes);
+        }
+
         public async Task<IEnumerable<Poll>> GetRecentAsync(int count = 10)
         {
             using var conn = _context.CreateConnection();

--- a/Frontend/components/app-shell/index.tsx
+++ b/Frontend/components/app-shell/index.tsx
@@ -5,6 +5,7 @@ import { TopBar } from "./top-bar"
 import { Sidebar } from "./sidebar"
 import { BottomNav } from "./bottom-nav"
 import { ProfileDrawer } from "./profile-drawer"
+import { SearchOverlay } from "@/components/search/search-overlay"
 import { cn } from "@/lib/utils"
 
 interface AppShellProps {
@@ -14,12 +15,14 @@ interface AppShellProps {
 
 export function AppShell({ children, hideBottomPadding }: AppShellProps) {
   const [isProfileOpen, setIsProfileOpen] = useState(false)
+  const [isSearchOpen, setIsSearchOpen] = useState(false)
 
   return (
     <div className="min-h-screen bg-background">
       {/* Top Bar */}
       <TopBar
         onProfileClick={() => setIsProfileOpen(true)}
+        onSearchClick={() => setIsSearchOpen(true)}
         notificationCount={3}
       />
 
@@ -43,6 +46,11 @@ export function AppShell({ children, hideBottomPadding }: AppShellProps) {
       <ProfileDrawer
         isOpen={isProfileOpen}
         onClose={() => setIsProfileOpen(false)}
+      />
+
+      <SearchOverlay
+        open={isSearchOpen}
+        onOpenChange={setIsSearchOpen}
       />
     </div>
   )

--- a/Frontend/components/app-shell/top-bar.tsx
+++ b/Frontend/components/app-shell/top-bar.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { motion } from "framer-motion"
-import { Bell, LogIn, LogOut } from "lucide-react"
+import { Bell, LogIn, LogOut, Search } from "lucide-react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { AppLogo } from "./app-logo"
@@ -11,10 +11,15 @@ import { useAuth } from "@/contexts/auth-context"
 
 interface TopBarProps {
   onProfileClick: () => void
+  onSearchClick: () => void
   notificationCount?: number
 }
 
-export function TopBar({ onProfileClick, notificationCount = 3 }: TopBarProps) {
+export function TopBar({
+  onProfileClick,
+  onSearchClick,
+  notificationCount = 3,
+}: TopBarProps) {
   const { user, isAuthenticated, logout } = useAuth()
   const router = useRouter()
 
@@ -33,6 +38,19 @@ export function TopBar({ onProfileClick, notificationCount = 3 }: TopBarProps) {
 
         {/* Right side */}
         <div className="flex items-center gap-2">
+          <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+            <Button
+              aria-label="Search polls"
+              className="h-10 w-10 rounded-xl"
+              onClick={onSearchClick}
+              size="icon"
+              type="button"
+              variant="ghost"
+            >
+              <Search className="h-5 w-5" />
+            </Button>
+          </motion.div>
+
           {isAuthenticated ? (
             <>
               {/* Notifications */}

--- a/Frontend/components/search/search-overlay.tsx
+++ b/Frontend/components/search/search-overlay.tsx
@@ -1,0 +1,130 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { Loader2, Search } from "lucide-react"
+import { Input } from "@/components/ui/input"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { SearchResultCard } from "@/components/search/search-result-card"
+import { pollsApi, type ApiPoll } from "@/lib/api"
+
+interface SearchOverlayProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function SearchOverlay({ open, onOpenChange }: SearchOverlayProps) {
+  const [query, setQuery] = useState("")
+  const [results, setResults] = useState<ApiPoll[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const trimmedQuery = useMemo(() => query.trim(), [query])
+
+  useEffect(() => {
+    if (!open) {
+      setQuery("")
+      setResults([])
+      setError(null)
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!open || !trimmedQuery) {
+      setResults([])
+      setLoading(false)
+      setError(null)
+      return
+    }
+
+    let cancelled = false
+    const timeout = window.setTimeout(() => {
+      setLoading(true)
+      setError(null)
+
+      pollsApi.search(trimmedQuery)
+        .then((data) => {
+          if (!cancelled) setResults(data)
+        })
+        .catch((err: Error) => {
+          if (!cancelled) setError(err.message)
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false)
+        })
+    }, 400)
+
+    return () => {
+      cancelled = true
+      window.clearTimeout(timeout)
+    }
+  }, [open, trimmedQuery])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="top-24 max-h-[calc(100vh-7rem)] translate-y-0 gap-0 overflow-hidden p-0 sm:max-w-2xl">
+        <DialogHeader className="sr-only">
+          <DialogTitle>Search polls</DialogTitle>
+          <DialogDescription>Search active polls by keyword.</DialogDescription>
+        </DialogHeader>
+
+        <div className="border-b border-border p-4 pr-12">
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              autoFocus
+              className="h-11 rounded-xl pl-9 text-base"
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search polls"
+              value={query}
+            />
+          </div>
+        </div>
+
+        <div className="max-h-[calc(100vh-13rem)] overflow-y-auto p-3">
+          {!trimmedQuery && (
+            <div className="py-12 text-center text-sm text-muted-foreground">
+              Search by keyword to find active polls.
+            </div>
+          )}
+
+          {trimmedQuery && loading && (
+            <div className="flex items-center justify-center gap-2 py-12 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Searching...
+            </div>
+          )}
+
+          {trimmedQuery && !loading && error && (
+            <div className="py-12 text-center text-sm text-destructive">
+              Could not search polls.
+            </div>
+          )}
+
+          {trimmedQuery && !loading && !error && results.length === 0 && (
+            <div className="py-12 text-center text-sm text-muted-foreground">
+              No polls found for {trimmedQuery}
+            </div>
+          )}
+
+          {trimmedQuery && !loading && !error && results.length > 0 && (
+            <div className="space-y-1">
+              {results.map((poll) => (
+                <SearchResultCard
+                  key={poll.id}
+                  poll={poll}
+                  onSelect={() => onOpenChange(false)}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/Frontend/components/search/search-result-card.tsx
+++ b/Frontend/components/search/search-result-card.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import { ImageOff, Newspaper, Users } from "lucide-react"
+import { useRouter } from "next/navigation"
+import type { ApiPoll } from "@/lib/api"
+import { SOURCE_COLORS, SOURCE_LABELS, type IngestionSource } from "@/lib/poll-data"
+import { cn } from "@/lib/utils"
+
+interface SearchResultCardProps {
+  poll: ApiPoll
+  onSelect: () => void
+}
+
+function sourceStyle(sourceType: string | null) {
+  const source = (sourceType ?? "manual") as IngestionSource
+  return SOURCE_COLORS[source] ?? SOURCE_COLORS.manual
+}
+
+function sourceLabel(sourceType: string | null) {
+  const source = (sourceType ?? "manual") as IngestionSource
+  return SOURCE_LABELS[source] ?? "Pollify"
+}
+
+export function SearchResultCard({ poll, onSelect }: SearchResultCardProps) {
+  const router = useRouter()
+  const style = sourceStyle(poll.sourceType)
+
+  function openPoll() {
+    onSelect()
+    router.push(`/polls/${poll.id}`)
+  }
+
+  return (
+    <button
+      className="flex w-full gap-3 rounded-xl p-2 text-left transition-colors hover:bg-secondary/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      onClick={openPoll}
+      type="button"
+    >
+      <div className="h-20 w-20 flex-shrink-0 overflow-hidden rounded-lg bg-secondary">
+        {poll.thumbnailUrl ? (
+          <img
+            alt=""
+            className="h-full w-full object-cover"
+            src={poll.thumbnailUrl}
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-muted-foreground">
+            <ImageOff className="h-6 w-6 opacity-50" />
+          </div>
+        )}
+      </div>
+
+      <div className="min-w-0 flex-1 space-y-2">
+        <h3 className="line-clamp-2 text-sm font-bold leading-snug text-foreground">
+          {poll.question}
+        </h3>
+        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+          <span className="rounded-full bg-secondary px-2 py-0.5 font-medium text-secondary-foreground">
+            {poll.category}
+          </span>
+          <span className="flex items-center gap-1">
+            <Users className="h-3.5 w-3.5" />
+            {poll.totalVotes.toLocaleString()}
+          </span>
+          <span
+            className={cn(
+              "flex items-center gap-1 rounded-full px-2 py-0.5 font-medium",
+              style.bg,
+              style.text
+            )}
+          >
+            <Newspaper className={cn("h-3.5 w-3.5", style.icon)} />
+            {sourceLabel(poll.sourceType)}
+          </span>
+        </div>
+      </div>
+    </button>
+  )
+}

--- a/Frontend/lib/api.ts
+++ b/Frontend/lib/api.ts
@@ -119,6 +119,13 @@ export const pollsApi = {
   /** Fetch one poll. Includes hasVoted when authenticated. */
   getById: (id: number | string) => request<ApiPoll>(`/api/polls/${id}`),
 
+  /** Search active polls by question. Includes hasVoted when authenticated. */
+  search: (q: string, category?: string) => {
+    const query = new URLSearchParams({ q })
+    if (category) query.set("category", category)
+    return request<ApiPoll[]>(`/api/polls/search?${query.toString()}`)
+  },
+
   /** Create a new poll. Returns the created poll. */
   create: (payload: CreatePollPayload) =>
     request<ApiPoll>("/api/polls", {


### PR DESCRIPTION
## Summary
- add `GET /api/polls/search?q=...` with optional category filtering, 50-poll limit, vote state, and total-vote ordering
- add `pollsApi.search(q, category)` to the frontend API client
- add a top-bar search button plus debounced search dialog with vertical result cards linking to poll detail pages

## Verification
- dotnet build *(passes with existing nullable warning in AuthRepository.cs)*
- ./node_modules/.bin/tsc --noEmit
- npm run build
- npm run lint *(fails: eslint is not installed in Frontend package)*

Closes #40