### PR TITLE
Support multi-option feed voting

### DIFF
--- a/Frontend/components/poll-feed/index.tsx
+++ b/Frontend/components/poll-feed/index.tsx
@@ -19,7 +19,7 @@ export function PollFeed() {
   const [currentIndex, setCurrentIndex]   = useState(0)
   const [streak, setStreak]               = useState(0)
   const [totalXp, setTotalXp]             = useState(1250)
-  const [currentVote, setCurrentVote]     = useState<"yes" | "no" | null>(null)
+  const [currentVote, setCurrentVote]     = useState<"yes" | "no" | "option" | null>(null)
   const [sessionXp, setSessionXp]         = useState(0)
 
   const currentPoll: Poll | undefined = polls[currentIndex]
@@ -40,22 +40,15 @@ export function PollFeed() {
   }, [])
 
   const handleVote = useCallback(
-    async (vote: "yes" | "no") => {
+    async (optionId: number, feedback: "yes" | "no" | "option") => {
       if (!currentPoll || currentVote) return
 
-      setCurrentVote(vote)
+      setCurrentVote(feedback)
       setStreak((s) => s + 1)
       setTotalXp((xp) => xp + currentPoll.xpReward)
       setSessionXp((xp) => xp + currentPoll.xpReward)
 
-      // Map yes → options[0], no → options[last]
-      if (currentPoll.options && currentPoll.options.length >= 2) {
-        const optionId =
-          vote === "yes"
-            ? currentPoll.options[0].id
-            : currentPoll.options[currentPoll.options.length - 1].id
-        await castVote(currentPoll.id, optionId)
-      }
+      await castVote(currentPoll.id, optionId)
     },
     [currentPoll, currentVote, castVote]
   )

--- a/Frontend/components/poll-feed/poll-card.tsx
+++ b/Frontend/components/poll-feed/poll-card.tsx
@@ -71,27 +71,46 @@ function VotedResultsBar({
   label: string
   percentage: number
   isUserVote: boolean
-  color: "emerald" | "red"
+  color: "emerald" | "red" | "blue" | "amber"
 }) {
-  const barColor   = color === "emerald" ? "bg-emerald-500" : "bg-red-500"
-  const textColor  = color === "emerald" ? "text-emerald-600 dark:text-emerald-400" : "text-red-600 dark:text-red-400"
-  const trackColor = color === "emerald" ? "bg-emerald-500/10" : "bg-red-500/10"
+  const styles = {
+    emerald: {
+      bar: "bg-emerald-500",
+      text: "text-emerald-600 dark:text-emerald-400",
+      track: "bg-emerald-500/10",
+    },
+    red: {
+      bar: "bg-red-500",
+      text: "text-red-600 dark:text-red-400",
+      track: "bg-red-500/10",
+    },
+    blue: {
+      bar: "bg-blue-500",
+      text: "text-blue-600 dark:text-blue-400",
+      track: "bg-blue-500/10",
+    },
+    amber: {
+      bar: "bg-amber-500",
+      text: "text-amber-600 dark:text-amber-400",
+      track: "bg-amber-500/10",
+    },
+  }[color]
 
   return (
     <div className="space-y-1.5">
       <div className="flex items-center justify-between text-sm font-medium">
-        <span className={cn("flex items-center gap-1.5", isUserVote ? textColor : "text-muted-foreground")}>
+        <span className={cn("flex min-w-0 items-center gap-1.5", isUserVote ? styles.text : "text-muted-foreground")}>
           {isUserVote && <CheckCircle2 className="h-4 w-4" />}
-          {label}
+          <span className="truncate">{label}</span>
           {isUserVote && <span className="text-xs font-normal opacity-70">(your vote)</span>}
         </span>
-        <span className={isUserVote ? textColor : "text-muted-foreground"}>
+        <span className={isUserVote ? styles.text : "text-muted-foreground"}>
           {Math.round(percentage)}%
         </span>
       </div>
-      <div className={cn("h-2.5 w-full overflow-hidden rounded-full", trackColor)}>
+      <div className={cn("h-2.5 w-full overflow-hidden rounded-full", styles.track)}>
         <motion.div
-          className={cn("h-full rounded-full", barColor)}
+          className={cn("h-full rounded-full", styles.bar)}
           initial={{ width: 0 }}
           animate={{ width: `${percentage}%` }}
           transition={{ duration: 0.6, ease: "easeOut", delay: 0.1 }}
@@ -104,7 +123,7 @@ function VotedResultsBar({
 // ── Component ─────────────────────────────────────────────────────────────────
 interface PollCardProps {
   poll: Poll
-  onVote: (vote: "yes" | "no") => void
+  onVote: (optionId: number, feedback: "yes" | "no" | "option") => void
   isActive: boolean
 }
 
@@ -127,16 +146,20 @@ export function PollCard({ poll, onVote, isActive }: PollCardProps) {
 
   // US-19: voted state
   const hasVoted        = poll.hasVoted ?? false
+  const pollOptions     = poll.options ?? []
+  const isBinaryPoll    = pollOptions.length <= 2
   const yesOption       = poll.options?.[0]
   const noOption        = poll.options?.[poll.options.length - 1]
-  const userVotedYes    = hasVoted && poll.userVotedOptionId === yesOption?.id
-  const userVotedNo     = hasVoted && poll.userVotedOptionId === noOption?.id
+  const resultColors    = ["emerald", "red", "blue", "amber"] as const
 
   function handleDragEnd(_: unknown, info: PanInfo) {
-    if (hasVoted) return                          // no drag on voted cards
+    if (hasVoted || !isBinaryPoll) return
     const threshold = 100
-    if (info.offset.x > threshold)       onVote("yes")
-    else if (info.offset.x < -threshold) onVote("no")
+    if (info.offset.x > threshold && yesOption) {
+      onVote(yesOption.id, "yes")
+    } else if (info.offset.x < -threshold && noOption) {
+      onVote(noOption.id, "no")
+    }
   }
 
   return (
@@ -144,10 +167,10 @@ export function PollCard({ poll, onVote, isActive }: PollCardProps) {
       className={cn(
         "absolute inset-x-4 top-0 h-full md:inset-x-0",
         !isActive && "pointer-events-none",
-        hasVoted ? "cursor-default" : "cursor-grab active:cursor-grabbing"
+        hasVoted || !isBinaryPoll ? "cursor-default" : "cursor-grab active:cursor-grabbing"
       )}
       style={{ x, rotate, zIndex: isActive ? 10 : 0 }}
-      drag={isActive && !hasVoted ? "x" : false}
+      drag={isActive && !hasVoted && isBinaryPoll ? "x" : false}
       dragConstraints={{ left: 0, right: 0 }}
       dragElastic={0.7}
       onDragEnd={handleDragEnd}
@@ -160,7 +183,7 @@ export function PollCard({ poll, onVote, isActive }: PollCardProps) {
       <div className="relative h-full overflow-hidden rounded-3xl bg-card shadow-2xl ring-1 ring-border/50">
 
         {/* YES / NO swipe overlays — hidden on voted cards */}
-        {!hasVoted && (
+        {!hasVoted && isBinaryPoll && (
           <>
             <motion.div
               className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center bg-emerald-500/20"
@@ -337,31 +360,45 @@ export function PollCard({ poll, onVote, isActive }: PollCardProps) {
                 animate={{ opacity: 1 }}
                 transition={{ duration: 0.3 }}
               >
-                {yesOption && (
+                {pollOptions.map((option, index) => (
                   <VotedResultsBar
-                    label={yesOption.text}
-                    percentage={yesOption.votePercentage}
-                    isUserVote={userVotedYes}
-                    color="emerald"
+                    color={resultColors[index % resultColors.length]}
+                    isUserVote={poll.userVotedOptionId === option.id}
+                    key={option.id}
+                    label={option.text}
+                    percentage={option.votePercentage}
                   />
-                )}
-                {noOption && noOption.id !== yesOption?.id && (
-                  <VotedResultsBar
-                    label={noOption.text}
-                    percentage={noOption.votePercentage}
-                    isUserVote={userVotedNo}
-                    color="red"
-                  />
-                )}
+                ))}
                 <p className="text-center text-xs text-muted-foreground pt-1">
                   You already voted
                 </p>
               </motion.div>
+            ) : !isBinaryPoll ? (
+              <div className="grid gap-2">
+                {pollOptions.map((option, index) => (
+                  <motion.button
+                    className={cn(
+                      "flex min-h-12 items-center justify-between gap-3 rounded-2xl px-4 py-3 text-left text-sm font-bold ring-2 transition-colors",
+                      index === 0 && "bg-emerald-500/10 text-emerald-600 ring-emerald-500/20 hover:bg-emerald-500/20",
+                      index === 1 && "bg-red-500/10 text-red-600 ring-red-500/20 hover:bg-red-500/20",
+                      index === 2 && "bg-blue-500/10 text-blue-600 ring-blue-500/20 hover:bg-blue-500/20",
+                      index >= 3 && "bg-amber-500/10 text-amber-600 ring-amber-500/20 hover:bg-amber-500/20"
+                    )}
+                    key={option.id}
+                    onClick={() => onVote(option.id, "option")}
+                    whileHover={{ scale: 1.01 }}
+                    whileTap={{ scale: 0.98 }}
+                  >
+                    <span className="line-clamp-2">{option.text}</span>
+                    <span className="text-xs opacity-70">+{poll.xpReward} XP</span>
+                  </motion.button>
+                ))}
+              </div>
             ) : (
               /* Normal swipe buttons */
               <div className="flex items-center gap-3">
                 <motion.button
-                  onClick={() => onVote("no")}
+                  onClick={() => noOption && onVote(noOption.id, "no")}
                   className="flex flex-1 items-center justify-center gap-2 rounded-2xl bg-red-500/10 py-4 font-bold text-red-500 ring-2 ring-red-500/20 transition-colors hover:bg-red-500/20"
                   whileHover={{ scale: 1.02 }}
                   whileTap={{ scale: 0.98 }}
@@ -369,7 +406,7 @@ export function PollCard({ poll, onVote, isActive }: PollCardProps) {
                   <span className="text-2xl">NO</span>
                 </motion.button>
                 <motion.button
-                  onClick={() => onVote("yes")}
+                  onClick={() => yesOption && onVote(yesOption.id, "yes")}
                   className="flex flex-1 items-center justify-center gap-2 rounded-2xl bg-emerald-500/10 py-4 font-bold text-emerald-500 ring-2 ring-emerald-500/20 transition-colors hover:bg-emerald-500/20"
                   whileHover={{ scale: 1.02 }}
                   whileTap={{ scale: 0.98 }}

--- a/Frontend/components/poll-feed/vote-feedback.tsx
+++ b/Frontend/components/poll-feed/vote-feedback.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from "react"
 import { cn } from "@/lib/utils"
 
 interface VoteFeedbackProps {
-  vote: "yes" | "no" | null
+  vote: "yes" | "no" | "option" | null
   xpEarned: number
   streakCount: number
   onComplete: () => void
@@ -44,23 +44,27 @@ export function VoteFeedback({
           <motion.div
             className={cn(
               "relative flex h-32 w-32 items-center justify-center rounded-full",
-              vote === "yes" ? "bg-emerald-500" : "bg-red-500"
+              vote === "yes" && "bg-emerald-500",
+              vote === "no" && "bg-red-500",
+              vote === "option" && "bg-primary"
             )}
             initial={{ scale: 0, rotate: -180 }}
             animate={{ scale: 1, rotate: 0 }}
             transition={{ type: "spring", stiffness: 260, damping: 20 }}
           >
-            {vote === "yes" ? (
-              <Check className="h-16 w-16 text-white" strokeWidth={3} />
-            ) : (
+            {vote === "no" ? (
               <X className="h-16 w-16 text-white" strokeWidth={3} />
+            ) : (
+              <Check className="h-16 w-16 text-white" strokeWidth={3} />
             )}
 
             {/* Ripple Effect */}
             <motion.div
               className={cn(
                 "absolute inset-0 rounded-full",
-                vote === "yes" ? "bg-emerald-500" : "bg-red-500"
+                vote === "yes" && "bg-emerald-500",
+                vote === "no" && "bg-red-500",
+                vote === "option" && "bg-primary"
               )}
               initial={{ scale: 1, opacity: 0.5 }}
               animate={{ scale: 2.5, opacity: 0 }}
@@ -69,7 +73,9 @@ export function VoteFeedback({
             <motion.div
               className={cn(
                 "absolute inset-0 rounded-full",
-                vote === "yes" ? "bg-emerald-500" : "bg-red-500"
+                vote === "yes" && "bg-emerald-500",
+                vote === "no" && "bg-red-500",
+                vote === "option" && "bg-primary"
               )}
               initial={{ scale: 1, opacity: 0.3 }}
               animate={{ scale: 3, opacity: 0 }}
@@ -114,7 +120,9 @@ export function VoteFeedback({
               key={i}
               className={cn(
                 "absolute h-3 w-3 rounded-full",
-                vote === "yes" ? "bg-emerald-400" : "bg-red-400"
+                vote === "yes" && "bg-emerald-400",
+                vote === "no" && "bg-red-400",
+                vote === "option" && "bg-primary"
               )}
               initial={{
                 scale: 0,


### PR DESCRIPTION
## Summary
- update feed voting to submit exact backend `OptionId` values
- keep binary polls swipeable with YES/NO buttons while rendering all options for 3-4 option polls
- show all option result bars after voting, with the selected option highlighted
- add neutral vote feedback styling for multi-option selections

## Verification
- ./node_modules/.bin/tsc --noEmit
- npm run build
- npm run lint *(fails: eslint is not installed in Frontend package)*

QA notes
- Binary polls keep swipe right/left and YES/NO buttons.
- 3- and 4-option polls render stacked option buttons and vote through the selected option id.
- Result bars iterate over every backend option instead of only first/last.

Closes #52