### PR TITLE
Add structured poll categories

### DIFF
--- a/Backend/BackendAPI/Migrations/US53_Categories_Schema.sql
+++ b/Backend/BackendAPI/Migrations/US53_Categories_Schema.sql
@@ -1,0 +1,78 @@
+IF OBJECT_ID('dbo.Categories', 'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.Categories (
+        Id INT NOT NULL PRIMARY KEY,
+        Name NVARCHAR(80) NOT NULL UNIQUE,
+        Slug NVARCHAR(80) NOT NULL UNIQUE,
+        Icon NVARCHAR(80) NOT NULL,
+        Color NVARCHAR(40) NOT NULL,
+        SortOrder INT NOT NULL,
+        IsActive BIT NOT NULL CONSTRAINT DF_Categories_IsActive DEFAULT 1
+    );
+END;
+
+MERGE dbo.Categories AS target
+USING (VALUES
+    (1, 'General', 'general', 'sparkles', 'slate', 10, 1),
+    (2, 'Technology', 'technology', 'cpu', 'blue', 20, 1),
+    (3, 'Society', 'society', 'users', 'rose', 30, 1),
+    (4, 'Work', 'work', 'briefcase', 'amber', 40, 1),
+    (5, 'Environment', 'environment', 'leaf', 'emerald', 50, 1),
+    (6, 'Culture', 'culture', 'palette', 'violet', 60, 1),
+    (7, 'Sports', 'sports', 'trophy', 'orange', 70, 1),
+    (8, 'Health', 'health', 'heart-pulse', 'teal', 80, 1),
+    (9, 'Politics', 'politics', 'landmark', 'indigo', 90, 1)
+) AS source (Id, Name, Slug, Icon, Color, SortOrder, IsActive)
+ON target.Id = source.Id
+WHEN MATCHED THEN
+    UPDATE SET
+        Name = source.Name,
+        Slug = source.Slug,
+        Icon = source.Icon,
+        Color = source.Color,
+        SortOrder = source.SortOrder,
+        IsActive = source.IsActive
+WHEN NOT MATCHED THEN
+    INSERT (Id, Name, Slug, Icon, Color, SortOrder, IsActive)
+    VALUES (source.Id, source.Name, source.Slug, source.Icon, source.Color, source.SortOrder, source.IsActive);
+
+UPDATE dbo.Polls
+SET Category = CASE
+    WHEN Category IS NULL OR LTRIM(RTRIM(Category)) = '' THEN 'General'
+    WHEN LOWER(LTRIM(RTRIM(Category))) = 'tech' THEN 'Technology'
+    WHEN LOWER(LTRIM(RTRIM(Category))) IN ('business', 'career', 'jobs') THEN 'Work'
+    WHEN LOWER(LTRIM(RTRIM(Category))) = 'climate' THEN 'Environment'
+    WHEN LOWER(LTRIM(RTRIM(Category))) IN ('entertainment', 'arts', 'movies') THEN 'Culture'
+    WHEN LOWER(LTRIM(RTRIM(Category))) IN ('wellness', 'medical', 'fitness') THEN 'Health'
+    WHEN LOWER(LTRIM(RTRIM(Category))) IN ('news', 'government') THEN 'Politics'
+    WHEN EXISTS (SELECT 1 FROM dbo.Categories c WHERE LOWER(c.Name) = LOWER(LTRIM(RTRIM(dbo.Polls.Category)))) THEN (
+        SELECT TOP 1 c.Name FROM dbo.Categories c WHERE LOWER(c.Name) = LOWER(LTRIM(RTRIM(dbo.Polls.Category)))
+    )
+    ELSE 'General'
+END;
+
+IF OBJECT_ID('dbo.TrendingTopics', 'U') IS NOT NULL
+BEGIN
+    UPDATE dbo.TrendingTopics
+    SET Category = CASE
+        WHEN Category IS NULL OR LTRIM(RTRIM(Category)) = '' THEN 'General'
+        WHEN LOWER(LTRIM(RTRIM(Category))) = 'tech' THEN 'Technology'
+        WHEN LOWER(LTRIM(RTRIM(Category))) IN ('business', 'career', 'jobs') THEN 'Work'
+        WHEN LOWER(LTRIM(RTRIM(Category))) = 'climate' THEN 'Environment'
+        WHEN LOWER(LTRIM(RTRIM(Category))) IN ('entertainment', 'arts', 'movies') THEN 'Culture'
+        WHEN LOWER(LTRIM(RTRIM(Category))) IN ('wellness', 'medical', 'fitness') THEN 'Health'
+        WHEN LOWER(LTRIM(RTRIM(Category))) IN ('news', 'government') THEN 'Politics'
+        WHEN EXISTS (SELECT 1 FROM dbo.Categories c WHERE LOWER(c.Name) = LOWER(LTRIM(RTRIM(dbo.TrendingTopics.Category)))) THEN (
+            SELECT TOP 1 c.Name FROM dbo.Categories c WHERE LOWER(c.Name) = LOWER(LTRIM(RTRIM(dbo.TrendingTopics.Category)))
+        )
+        ELSE 'General'
+    END;
+END;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE name = 'IX_Polls_Category' AND object_id = OBJECT_ID('dbo.Polls')
+)
+BEGIN
+    CREATE INDEX IX_Polls_Category ON dbo.Polls (Category);
+END;

--- a/Backend/BackendAPI/Models/Category.cs
+++ b/Backend/BackendAPI/Models/Category.cs
@@ -1,0 +1,87 @@
+namespace BackendAPI.Models
+{
+    public sealed record PollCategory(
+        int Id,
+        string Name,
+        string Slug,
+        string Icon,
+        string Color,
+        int SortOrder,
+        bool IsActive = true);
+
+    public static class CategoryCatalog
+    {
+        public const string DefaultCategoryName = "General";
+
+        public static readonly IReadOnlyList<PollCategory> All = new List<PollCategory>
+        {
+            new(1, DefaultCategoryName, "general", "sparkles", "slate", 10),
+            new(2, "Technology", "technology", "cpu", "blue", 20),
+            new(3, "Society", "society", "users", "rose", 30),
+            new(4, "Work", "work", "briefcase", "amber", 40),
+            new(5, "Environment", "environment", "leaf", "emerald", 50),
+            new(6, "Culture", "culture", "palette", "violet", 60),
+            new(7, "Sports", "sports", "trophy", "orange", 70),
+            new(8, "Health", "health", "heart-pulse", "teal", 80),
+            new(9, "Politics", "politics", "landmark", "indigo", 90),
+        };
+
+        private static readonly Dictionary<string, PollCategory> ByName =
+            All.ToDictionary(c => c.Name, StringComparer.OrdinalIgnoreCase);
+
+        private static readonly Dictionary<string, PollCategory> BySlug =
+            All.ToDictionary(c => c.Slug, StringComparer.OrdinalIgnoreCase);
+
+        private static readonly Dictionary<string, string> Aliases =
+            new(StringComparer.OrdinalIgnoreCase)
+            {
+                ["tech"] = "Technology",
+                ["business"] = "Work",
+                ["career"] = "Work",
+                ["jobs"] = "Work",
+                ["climate"] = "Environment",
+                ["entertainment"] = "Culture",
+                ["arts"] = "Culture",
+                ["movies"] = "Culture",
+                ["wellness"] = "Health",
+                ["medical"] = "Health",
+                ["fitness"] = "Health",
+                ["news"] = "Politics",
+                ["government"] = "Politics",
+            };
+
+        public static PollCategory Normalize(string? category)
+        {
+            if (string.IsNullOrWhiteSpace(category))
+            {
+                return ByName[DefaultCategoryName];
+            }
+
+            var key = category.Trim();
+            if (ByName.TryGetValue(key, out var byName))
+            {
+                return byName;
+            }
+
+            var slug = Slugify(key);
+            if (BySlug.TryGetValue(slug, out var bySlug))
+            {
+                return bySlug;
+            }
+
+            if (Aliases.TryGetValue(key, out var aliasName) || Aliases.TryGetValue(slug, out aliasName))
+            {
+                return ByName[aliasName];
+            }
+
+            return ByName[DefaultCategoryName];
+        }
+
+        public static string NormalizeName(string? category) => Normalize(category).Name;
+
+        private static string Slugify(string value)
+        {
+            return value.Trim().ToLowerInvariant().Replace(" ", "-").Replace("_", "-");
+        }
+    }
+}

--- a/Backend/BackendAPI/Repository/PollsRepository.cs
+++ b/Backend/BackendAPI/Repository/PollsRepository.cs
@@ -32,6 +32,13 @@ namespace BackendAPI.Repository
             return rows.ToDictionary(r => r.PollId, r => r.OptionId);
         }
 
+        private static string? NormalizeFilterCategory(string? category)
+        {
+            return string.IsNullOrWhiteSpace(category)
+                ? null
+                : CategoryCatalog.NormalizeName(category);
+        }
+
         /// <summary>Applies HasVoted / UserVotedOptionId to a list of polls in-memory.</summary>
         private static IEnumerable<Poll> ApplyVoteState(
             IEnumerable<Poll> polls,
@@ -54,9 +61,7 @@ namespace BackendAPI.Repository
         {
             using var conn = _context.CreateConnection();
             var pollDict   = new Dictionary<long, Poll>();
-            var normalizedCategory = string.IsNullOrWhiteSpace(category)
-                ? null
-                : category.Trim();
+            var normalizedCategory = NormalizeFilterCategory(category);
 
             await conn.QueryAsync<Poll, PollOption, Poll>(
                 @"SELECT p.*, u.Username AS CreatedByUsername, u.DisplayName AS CreatedByDisplayName, o.*
@@ -123,9 +128,7 @@ namespace BackendAPI.Repository
         {
             using var conn = _context.CreateConnection();
             var pollDict   = new Dictionary<long, Poll>();
-            var normalizedCategory = string.IsNullOrWhiteSpace(category)
-                ? null
-                : category.Trim();
+            var normalizedCategory = NormalizeFilterCategory(category);
 
             // US-09: order by TotalVotes DESC directly
             await conn.QueryAsync<Poll, PollOption, Poll>(
@@ -161,9 +164,7 @@ namespace BackendAPI.Repository
         {
             using var conn = _context.CreateConnection();
             var pollDict   = new Dictionary<long, Poll>();
-            var normalizedCategory = string.IsNullOrWhiteSpace(category)
-                ? null
-                : category.Trim();
+            var normalizedCategory = NormalizeFilterCategory(category);
 
             await conn.QueryAsync<Poll, PollOption, Poll>(
                 @"WITH SearchPolls AS (
@@ -235,6 +236,7 @@ namespace BackendAPI.Repository
             using var conn = _context.CreateConnection();
             conn.Open();
             using var transaction = conn.BeginTransaction();
+            var normalizedCategory = CategoryCatalog.NormalizeName(request.Category);
 
             try
             {
@@ -252,7 +254,7 @@ namespace BackendAPI.Repository
                     {
                         request.Question,
                         request.Description,
-                        request.Category,
+                        Category = normalizedCategory,
                         request.ExpiresAt,
                         request.SourceType,
                         request.SourceUrl,

--- a/Backend/BackendAPI/Repository/TrendingTopicRepository.cs
+++ b/Backend/BackendAPI/Repository/TrendingTopicRepository.cs
@@ -26,6 +26,8 @@ namespace BackendAPI.Repository
 
             foreach (var topic in topics)
             {
+                var normalizedCategory = CategoryCatalog.NormalizeName(topic.Category);
+
                 await conn.ExecuteAsync(@"
                     IF NOT EXISTS (
                         SELECT 1 FROM TrendingTopics
@@ -44,7 +46,7 @@ namespace BackendAPI.Repository
                         topic.SourceType,
                         SourceUrl    = topic.SourceUrl ?? "",
                         topic.ThumbnailUrl,
-                        topic.Category
+                        Category = normalizedCategory
                     });
             }
         }

--- a/Backend/BackendAPI/Services/PollGenerationService.cs
+++ b/Backend/BackendAPI/Services/PollGenerationService.cs
@@ -79,6 +79,7 @@ namespace BackendAPI.Services
             var summary = string.IsNullOrWhiteSpace(topic.Summary)
                 ? "(no summary available)"
                 : topic.Summary;
+            var validCategories = string.Join(", ", CategoryCatalog.All.Select(category => category.Name));
 
             // $$""" = raw string with double-dollar: {{ }} = interpolation, { } = literal braces
             return $$"""
@@ -88,6 +89,7 @@ namespace BackendAPI.Services
                 Topic: {{topic.Title}}
                 Summary: {{summary}}
                 Category: {{topic.Category}}
+                Valid categories: {{validCategories}}
 
                 Respond with ONLY valid JSON — no markdown, no explanation:
                 {
@@ -99,7 +101,7 @@ namespace BackendAPI.Services
                 Rules:
                 - Question must be opinionated, specific and under 120 characters
                 - 2 to 4 options, mutually exclusive, short (under 40 chars each)
-                - Category must match the topic (e.g. Politics, Technology, Sports)
+                - Category must be one of the valid categories
                 - JSON only — no other text
                 """;
         }
@@ -155,11 +157,13 @@ namespace BackendAPI.Services
 
                 if (options.Count < 2) return null;
 
+                var resolvedCategory = string.IsNullOrWhiteSpace(category) ? fallbackCategory : category;
+
                 return new GeneratedPoll
                 {
                     Question = question!,
                     Options  = options,
-                    Category = string.IsNullOrWhiteSpace(category) ? fallbackCategory : category!
+                    Category = CategoryCatalog.NormalizeName(resolvedCategory)
                 };
             }
             catch

--- a/Frontend/app/page.tsx
+++ b/Frontend/app/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link"
 import { BarChart3, ChevronRight, Clock, Loader2, Plus, TrendingUp, Trophy, Users, Zap } from "lucide-react"
 import { motion } from "framer-motion"
 import { AppShell } from "@/components/app-shell"
+import { CategoryBadge } from "@/components/category-badge"
 import { Button } from "@/components/ui/button"
 import { useAuth } from "@/contexts/auth-context"
 import { pollsApi, type ApiPoll } from "@/lib/api"
@@ -140,9 +141,7 @@ export default function HomePage() {
                   <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0 flex-1">
                       <div className="mb-2 flex items-center gap-2">
-                        <span className="rounded-full bg-secondary px-2.5 py-0.5 text-xs font-medium text-secondary-foreground">
-                          {poll.category}
-                        </span>
+                        <CategoryBadge category={poll.category} className="px-2.5 py-0.5" />
                         {poll.isTrending && (
                           <span className="flex items-center gap-1 text-xs font-medium text-primary">
                             <TrendingUp className="h-3 w-3" />

--- a/Frontend/app/profile/page.tsx
+++ b/Frontend/app/profile/page.tsx
@@ -16,6 +16,7 @@ import {
   CheckCircle2,
 } from "lucide-react"
 import { AppShell } from "@/components/app-shell"
+import { CategoryBadge } from "@/components/category-badge"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
@@ -232,9 +233,7 @@ export default function ProfilePage() {
                   <div className="min-w-0 flex-1">
                     <h3 className="line-clamp-2 font-medium text-foreground">{item.question}</h3>
                     <div className="mt-1.5 flex flex-wrap items-center gap-2">
-                      <span className="rounded-full bg-secondary px-2 py-0.5 text-xs text-secondary-foreground">
-                        {item.category}
-                      </span>
+                      <CategoryBadge category={item.category} className="px-2 py-0.5" />
                       <span className="flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
                         <CheckCircle2 className="h-3.5 w-3.5" />
                         {item.votedOptionText}

--- a/Frontend/components/category-badge.tsx
+++ b/Frontend/components/category-badge.tsx
@@ -1,0 +1,48 @@
+import {
+  Briefcase,
+  Cpu,
+  HeartPulse,
+  Landmark,
+  Leaf,
+  Palette,
+  Sparkles,
+  Trophy,
+  Users,
+} from "lucide-react"
+import { categoryMeta } from "@/lib/categories"
+import { cn } from "@/lib/utils"
+
+const CATEGORY_ICONS = {
+  briefcase: Briefcase,
+  cpu: Cpu,
+  "heart-pulse": HeartPulse,
+  landmark: Landmark,
+  leaf: Leaf,
+  palette: Palette,
+  sparkles: Sparkles,
+  trophy: Trophy,
+  users: Users,
+}
+
+interface CategoryBadgeProps {
+  category: string | null | undefined
+  className?: string
+}
+
+export function CategoryBadge({ category, className }: CategoryBadgeProps) {
+  const meta = categoryMeta(category)
+  const Icon = CATEGORY_ICONS[meta.icon as keyof typeof CATEGORY_ICONS] ?? Sparkles
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold ring-1",
+        meta.badgeClassName,
+        className
+      )}
+    >
+      <Icon className="h-3.5 w-3.5" />
+      {meta.name}
+    </span>
+  )
+}

--- a/Frontend/components/poll-create/index.tsx
+++ b/Frontend/components/poll-create/index.tsx
@@ -14,6 +14,7 @@ import { PrivacyStep } from "./steps/privacy-step"
 import { PreviewStep } from "./steps/preview-step"
 import { getInitialDraft, STEPS, type PollDraft } from "@/lib/poll-creation"
 import { pollsApi } from "@/lib/api"
+import { DEFAULT_CATEGORY } from "@/lib/categories"
 import { cn } from "@/lib/utils"
 
 export function PollCreator() {
@@ -68,7 +69,7 @@ export function PollCreator() {
       await pollsApi.create({
         question:    draft.question.trim(),
         description: draft.description.trim(),
-        category:    "General",
+        category:    DEFAULT_CATEGORY,
         expiresAt,
         options:     ["Yes", "No"],          // default binary options
         sourceType:  "manual",

--- a/Frontend/components/poll-detail/poll-detail-card.tsx
+++ b/Frontend/components/poll-detail/poll-detail-card.tsx
@@ -15,6 +15,7 @@ import {
   Zap,
 } from "lucide-react"
 import { motion } from "framer-motion"
+import { CategoryBadge } from "@/components/category-badge"
 import { ShareButton } from "@/components/share-button"
 import { Button } from "@/components/ui/button"
 import { useAuth } from "@/contexts/auth-context"
@@ -259,9 +260,7 @@ export function PollDetailCard({ pollId }: PollDetailCardProps) {
 
         <div className="space-y-5 p-5 md:p-7">
           <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
-            <span className="rounded-full bg-secondary px-3 py-1 text-xs font-medium text-secondary-foreground">
-              {poll.category}
-            </span>
+            <CategoryBadge category={poll.category} />
             <span className="flex items-center gap-1.5">
               <Clock className="h-4 w-4" />
               {relativeTime(poll.createdAt)}

--- a/Frontend/components/poll-feed/category-chips.tsx
+++ b/Frontend/components/poll-feed/category-chips.tsx
@@ -2,19 +2,8 @@
 
 import { useEffect, useRef } from "react"
 import { motion } from "framer-motion"
+import { categoryMeta, FEED_CATEGORIES } from "@/lib/categories"
 import { cn } from "@/lib/utils"
-
-export const FEED_CATEGORIES = [
-  "All",
-  "Technology",
-  "Society",
-  "Work",
-  "Environment",
-  "Culture",
-  "Sports",
-  "Health",
-  "Politics",
-] as const
 
 interface CategoryChipsProps {
   selected: string
@@ -35,6 +24,7 @@ export function CategoryChips({ selected, onSelect }: CategoryChipsProps) {
       <div className="flex gap-2 overflow-x-auto scroll-smooth px-4 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         {FEED_CATEGORIES.map((category) => {
           const active = selected === category
+          const meta = category === "All" ? null : categoryMeta(category)
 
           return (
             <motion.button
@@ -43,7 +33,7 @@ export function CategoryChips({ selected, onSelect }: CategoryChipsProps) {
                 "relative h-9 flex-shrink-0 rounded-full px-4 text-sm font-semibold transition-colors",
                 active
                   ? "bg-primary text-primary-foreground shadow-sm"
-                  : "bg-secondary text-secondary-foreground hover:bg-secondary/80"
+                  : meta?.chipClassName ?? "bg-secondary text-secondary-foreground hover:bg-secondary/80"
               )}
               key={category}
               ref={(node) => {

--- a/Frontend/components/poll-feed/index.tsx
+++ b/Frontend/components/poll-feed/index.tsx
@@ -3,7 +3,8 @@
 import { useState, useCallback, useEffect } from "react"
 import { motion, AnimatePresence } from "framer-motion"
 import { RefreshCw, Sparkles, AlertCircle, Loader2 } from "lucide-react"
-import { CategoryChips, FEED_CATEGORIES } from "./category-chips"
+import { FEED_CATEGORIES, normalizeCategoryName } from "@/lib/categories"
+import { CategoryChips } from "./category-chips"
 import { PollCard } from "./poll-card"
 import { VoteFeedback } from "./vote-feedback"
 import { StreakCounter } from "./streak-counter"
@@ -27,8 +28,15 @@ export function PollFeed() {
 
   useEffect(() => {
     const saved = window.localStorage.getItem("poll-feed-category")
-    if (saved && FEED_CATEGORIES.includes(saved as (typeof FEED_CATEGORIES)[number])) {
+    if (!saved) return
+    if (saved === "All") {
       setSelectedCategory(saved)
+      return
+    }
+
+    const normalized = normalizeCategoryName(saved)
+    if (FEED_CATEGORIES.includes(normalized as (typeof FEED_CATEGORIES)[number])) {
+      setSelectedCategory(normalized)
     }
   }, [])
 

--- a/Frontend/components/poll-feed/poll-card.tsx
+++ b/Frontend/components/poll-feed/poll-card.tsx
@@ -16,6 +16,7 @@ import {
   CheckCircle2,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
+import { CategoryBadge } from "@/components/category-badge"
 import { ShareButton } from "@/components/share-button"
 import { Poll, SOURCE_COLORS, SOURCE_LABELS } from "@/lib/poll-data"
 import {
@@ -316,9 +317,7 @@ export function PollCard({ poll, onVote, isActive }: PollCardProps) {
         <div className="flex h-[45%] flex-col p-5">
           {/* Category & Time */}
           <div className="mb-3 flex flex-shrink-0 items-center gap-3">
-            <span className="rounded-full bg-secondary px-3 py-1 text-xs font-medium text-secondary-foreground">
-              {poll.category}
-            </span>
+            <CategoryBadge category={poll.category} />
             <span className="flex items-center gap-1 text-xs text-muted-foreground">
               <Clock className="h-3 w-3" />
               {poll.timePosted}

--- a/Frontend/components/search/search-result-card.tsx
+++ b/Frontend/components/search/search-result-card.tsx
@@ -2,6 +2,7 @@
 
 import { ImageOff, Newspaper, Users } from "lucide-react"
 import { useRouter } from "next/navigation"
+import { CategoryBadge } from "@/components/category-badge"
 import type { ApiPoll } from "@/lib/api"
 import { SOURCE_COLORS, SOURCE_LABELS, type IngestionSource } from "@/lib/poll-data"
 import { cn } from "@/lib/utils"
@@ -55,9 +56,7 @@ export function SearchResultCard({ poll, onSelect }: SearchResultCardProps) {
           {poll.question}
         </h3>
         <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-          <span className="rounded-full bg-secondary px-2 py-0.5 font-medium text-secondary-foreground">
-            {poll.category}
-          </span>
+          <CategoryBadge category={poll.category} className="px-2 py-0.5" />
           <span className="flex items-center gap-1">
             <Users className="h-3.5 w-3.5" />
             {poll.totalVotes.toLocaleString()}

--- a/Frontend/lib/categories.ts
+++ b/Frontend/lib/categories.ts
@@ -1,0 +1,162 @@
+export type PollCategory = {
+  id: number
+  name: string
+  slug: string
+  icon: string
+  color: string
+  sortOrder: number
+  isActive: boolean
+  chipClassName: string
+  badgeClassName: string
+}
+
+export const DEFAULT_CATEGORY = "General"
+
+export const POLL_CATEGORIES: PollCategory[] = [
+  {
+    id: 1,
+    name: DEFAULT_CATEGORY,
+    slug: "general",
+    icon: "sparkles",
+    color: "slate",
+    sortOrder: 10,
+    isActive: true,
+    chipClassName: "bg-slate-500/10 text-slate-700 hover:bg-slate-500/15 dark:text-slate-300",
+    badgeClassName: "bg-slate-500/10 text-slate-700 ring-slate-500/20 dark:text-slate-300",
+  },
+  {
+    id: 2,
+    name: "Technology",
+    slug: "technology",
+    icon: "cpu",
+    color: "blue",
+    sortOrder: 20,
+    isActive: true,
+    chipClassName: "bg-blue-500/10 text-blue-700 hover:bg-blue-500/15 dark:text-blue-300",
+    badgeClassName: "bg-blue-500/10 text-blue-700 ring-blue-500/20 dark:text-blue-300",
+  },
+  {
+    id: 3,
+    name: "Society",
+    slug: "society",
+    icon: "users",
+    color: "rose",
+    sortOrder: 30,
+    isActive: true,
+    chipClassName: "bg-rose-500/10 text-rose-700 hover:bg-rose-500/15 dark:text-rose-300",
+    badgeClassName: "bg-rose-500/10 text-rose-700 ring-rose-500/20 dark:text-rose-300",
+  },
+  {
+    id: 4,
+    name: "Work",
+    slug: "work",
+    icon: "briefcase",
+    color: "amber",
+    sortOrder: 40,
+    isActive: true,
+    chipClassName: "bg-amber-500/10 text-amber-700 hover:bg-amber-500/15 dark:text-amber-300",
+    badgeClassName: "bg-amber-500/10 text-amber-700 ring-amber-500/20 dark:text-amber-300",
+  },
+  {
+    id: 5,
+    name: "Environment",
+    slug: "environment",
+    icon: "leaf",
+    color: "emerald",
+    sortOrder: 50,
+    isActive: true,
+    chipClassName: "bg-emerald-500/10 text-emerald-700 hover:bg-emerald-500/15 dark:text-emerald-300",
+    badgeClassName: "bg-emerald-500/10 text-emerald-700 ring-emerald-500/20 dark:text-emerald-300",
+  },
+  {
+    id: 6,
+    name: "Culture",
+    slug: "culture",
+    icon: "palette",
+    color: "violet",
+    sortOrder: 60,
+    isActive: true,
+    chipClassName: "bg-violet-500/10 text-violet-700 hover:bg-violet-500/15 dark:text-violet-300",
+    badgeClassName: "bg-violet-500/10 text-violet-700 ring-violet-500/20 dark:text-violet-300",
+  },
+  {
+    id: 7,
+    name: "Sports",
+    slug: "sports",
+    icon: "trophy",
+    color: "orange",
+    sortOrder: 70,
+    isActive: true,
+    chipClassName: "bg-orange-500/10 text-orange-700 hover:bg-orange-500/15 dark:text-orange-300",
+    badgeClassName: "bg-orange-500/10 text-orange-700 ring-orange-500/20 dark:text-orange-300",
+  },
+  {
+    id: 8,
+    name: "Health",
+    slug: "health",
+    icon: "heart-pulse",
+    color: "teal",
+    sortOrder: 80,
+    isActive: true,
+    chipClassName: "bg-teal-500/10 text-teal-700 hover:bg-teal-500/15 dark:text-teal-300",
+    badgeClassName: "bg-teal-500/10 text-teal-700 ring-teal-500/20 dark:text-teal-300",
+  },
+  {
+    id: 9,
+    name: "Politics",
+    slug: "politics",
+    icon: "landmark",
+    color: "indigo",
+    sortOrder: 90,
+    isActive: true,
+    chipClassName: "bg-indigo-500/10 text-indigo-700 hover:bg-indigo-500/15 dark:text-indigo-300",
+    badgeClassName: "bg-indigo-500/10 text-indigo-700 ring-indigo-500/20 dark:text-indigo-300",
+  },
+]
+
+export const FEED_CATEGORIES = [
+  "All",
+  ...POLL_CATEGORIES.filter((category) => category.isActive).map((category) => category.name),
+] as const
+
+const CATEGORY_ALIASES: Record<string, string> = {
+  tech: "Technology",
+  business: "Work",
+  career: "Work",
+  jobs: "Work",
+  climate: "Environment",
+  entertainment: "Culture",
+  arts: "Culture",
+  movies: "Culture",
+  wellness: "Health",
+  medical: "Health",
+  fitness: "Health",
+  news: "Politics",
+  government: "Politics",
+}
+
+function slugify(value: string) {
+  return value.trim().toLowerCase().replace(/\s+/g, "-").replace(/_/g, "-")
+}
+
+export function categoryMeta(category: string | null | undefined): PollCategory {
+  if (!category?.trim()) {
+    return POLL_CATEGORIES[0]
+  }
+
+  const value = category.trim()
+  const slug = slugify(value)
+  const alias = CATEGORY_ALIASES[value.toLowerCase()] ?? CATEGORY_ALIASES[slug]
+
+  return (
+    POLL_CATEGORIES.find(
+      (item) => item.name.toLowerCase() === value.toLowerCase() || item.slug === slug
+    ) ??
+    POLL_CATEGORIES.find((item) => item.name === alias) ??
+    POLL_CATEGORIES[0]
+  )
+}
+
+export function normalizeCategoryName(category: string | null | undefined) {
+  return categoryMeta(category).name
+}

--- a/Frontend/lib/poll-data.ts
+++ b/Frontend/lib/poll-data.ts
@@ -1,4 +1,5 @@
 import type { ApiPoll } from "./api"
+import { normalizeCategoryName } from "./categories"
 
 // ── Source types ─────────────────────────────────────────────────────────────
 // Legacy UI sources (used by existing mock cards)
@@ -76,7 +77,7 @@ export function mapBackendPoll(p: ApiPoll): Poll {
   return {
     id:           String(p.id),
     question:     p.question,
-    category:     p.category,
+    category:     normalizeCategoryName(p.category),
     trending:     p.isTrending,
     mediaType:    "image",
     mediaUrl:     p.thumbnailUrl ?? PLACEHOLDER_IMAGE,


### PR DESCRIPTION
## Summary
- add a structured category catalog plus database migration for canonical category metadata and legacy category normalization
- normalize poll/trending-topic category writes and category filters on the backend, with unknown categories falling back to General
- update AI poll generation prompts/parsing to use valid categories only
- centralize frontend category metadata and reuse it for feed chips and category badges across feed, detail, search, home, and profile views

## Verification
- `dotnet build` (passes; existing nullable warning remains in `Backend/BackendAPI/Repository/AuthRepository.cs`)
- `./node_modules/.bin/tsc --noEmit`
- `npm run build`
- `git diff --check`
- `npm run lint` is blocked because `eslint` is not installed in the frontend package

Closes #53