### PR TITLE
Add poll moderation workflow

### DIFF
--- a/Backend/BackendAPI/Controllers/PollsController.cs
+++ b/Backend/BackendAPI/Controllers/PollsController.cs
@@ -11,10 +11,12 @@ namespace BackendAPI.Controllers
     public class PollsController : ControllerBase
     {
         private readonly IPollsRepository _pollsRepo;
+        private readonly IConfiguration _config;
 
-        public PollsController(IPollsRepository pollsRepo)
+        public PollsController(IPollsRepository pollsRepo, IConfiguration config)
         {
             _pollsRepo = pollsRepo;
+            _config = config;
         }
 
         // ── Helper: extract userId from JWT if present (US-16) ────────────────
@@ -23,6 +25,19 @@ namespace BackendAPI.Controllers
             var claim = User.FindFirst(ClaimTypes.NameIdentifier)
                      ?? User.FindFirst("sub");
             return claim != null && long.TryParse(claim.Value, out var id) ? id : null;
+        }
+
+        private bool CurrentUserCanModerate(long userId)
+        {
+            if (_config.GetValue<bool>("Moderation:AllowAuthenticatedReviewers"))
+                return true;
+
+            var reviewerIds = _config["Moderation:ReviewerUserIds"];
+            if (string.IsNullOrWhiteSpace(reviewerIds)) return false;
+
+            return reviewerIds
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Any(value => long.TryParse(value, out var reviewerId) && reviewerId == userId);
         }
 
         // GET /api/polls
@@ -56,6 +71,21 @@ namespace BackendAPI.Controllers
             return Ok(polls);
         }
 
+        // GET /api/polls/moderation
+        [HttpGet("moderation")]
+        [Authorize]
+        public async Task<IActionResult> GetModerationQueue(
+            [FromQuery] string? status = null,
+            [FromQuery] int count = 50)
+        {
+            var userId = CurrentUserId();
+            if (userId == null) return Unauthorized(new { message = "Invalid token." });
+            if (!CurrentUserCanModerate(userId.Value)) return Forbid();
+
+            var polls = await _pollsRepo.GetModerationQueueAsync(status, Math.Clamp(count, 1, 100));
+            return Ok(polls);
+        }
+
         // GET /api/polls/{id}
         [HttpGet("{id}")]
         public async Task<IActionResult> GetById(long id)
@@ -82,6 +112,40 @@ namespace BackendAPI.Controllers
             var id = await _pollsRepo.CreateAsync(request, userId);
             var poll = await _pollsRepo.GetByIdAsync(id, userId);
             return CreatedAtAction(nameof(GetById), new { id }, poll);
+        }
+
+        // POST /api/polls/{id}/report
+        [HttpPost("{id}/report")]
+        [Authorize]
+        public async Task<IActionResult> Report(long id, [FromBody] ReportPollRequest request)
+        {
+            var userId = CurrentUserId();
+            if (userId == null) return Unauthorized(new { message = "Invalid token." });
+
+            var success = await _pollsRepo.ReportAsync(id, userId.Value, request.Reason);
+            if (!success) return NotFound(new { message = $"Poll {id} not found." });
+
+            return Ok(new { message = "Poll reported for review." });
+        }
+
+        // PATCH /api/polls/{id}/moderation
+        [HttpPatch("{id}/moderation")]
+        [Authorize]
+        public async Task<IActionResult> Moderate(long id, [FromBody] ModeratePollRequest request)
+        {
+            var userId = CurrentUserId();
+            if (userId == null) return Unauthorized(new { message = "Invalid token." });
+            if (!CurrentUserCanModerate(userId.Value)) return Forbid();
+
+            var status = PollModerationStatus.Normalize(request.Status);
+            if (status == PollModerationStatus.Rejected && string.IsNullOrWhiteSpace(request.Reason))
+                return BadRequest(new { message = "A rejection reason is required." });
+
+            var success = await _pollsRepo.ModerateAsync(id, status, request.Reason, userId.Value);
+            if (!success) return NotFound(new { message = $"Poll {id} not found." });
+
+            var poll = await _pollsRepo.GetByIdAsync(id, userId.Value);
+            return Ok(poll);
         }
 
         // DELETE /api/polls/{id}

--- a/Backend/BackendAPI/Controllers/VotesController.cs
+++ b/Backend/BackendAPI/Controllers/VotesController.cs
@@ -47,6 +47,9 @@ namespace BackendAPI.Controllers
             if (!poll.IsActive || poll.ExpiresAt < DateTime.UtcNow)
                 return BadRequest(new { message = "This poll has expired or is no longer active." });
 
+            if (!poll.ModerationStatus.Equals(PollModerationStatus.Published, StringComparison.OrdinalIgnoreCase))
+                return BadRequest(new { message = "This poll is not open for voting." });
+
             var validOption = poll.Options.Any(o => o.Id == request.OptionId);
             if (!validOption)
                 return BadRequest(new { message = "Invalid option for this poll." });

--- a/Backend/BackendAPI/Interfaces/IPollsRepository.cs
+++ b/Backend/BackendAPI/Interfaces/IPollsRepository.cs
@@ -10,7 +10,10 @@ namespace BackendAPI.Interfaces
         Task<IEnumerable<Poll>> GetTrendingAsync(int count = 10, long? userId = null, string? category = null);
         Task<IEnumerable<Poll>> SearchAsync(string query, string? category = null, long? userId = null);
         Task<IEnumerable<Poll>> GetRecentAsync(int count = 10);
+        Task<IEnumerable<Poll>> GetModerationQueueAsync(string? status = null, int count = 50);
         Task<long> CreateAsync(CreatePollRequest request, long? createdByUserId = null);
+        Task<bool> ReportAsync(long pollId, long reportedByUserId, string reason);
+        Task<bool> ModerateAsync(long pollId, string status, string? reason, long moderatedByUserId);
         Task<bool> DeleteAsync(long id);
         Task UpdateTrendingAsync();
     }

--- a/Backend/BackendAPI/Migrations/US54_Poll_Moderation.sql
+++ b/Backend/BackendAPI/Migrations/US54_Poll_Moderation.sql
@@ -1,0 +1,67 @@
+IF COL_LENGTH('dbo.Polls', 'ModerationStatus') IS NULL
+BEGIN
+    ALTER TABLE dbo.Polls
+        ADD ModerationStatus NVARCHAR(40) NOT NULL
+            CONSTRAINT DF_Polls_ModerationStatus DEFAULT 'Published';
+END;
+
+IF COL_LENGTH('dbo.Polls', 'ModerationReason') IS NULL
+BEGIN
+    ALTER TABLE dbo.Polls ADD ModerationReason NVARCHAR(1000) NULL;
+END;
+
+IF COL_LENGTH('dbo.Polls', 'ModeratedByUserId') IS NULL
+BEGIN
+    ALTER TABLE dbo.Polls ADD ModeratedByUserId BIGINT NULL;
+END;
+
+IF COL_LENGTH('dbo.Polls', 'ModeratedAt') IS NULL
+BEGIN
+    ALTER TABLE dbo.Polls ADD ModeratedAt DATETIME2 NULL;
+END;
+
+IF COL_LENGTH('dbo.Polls', 'ReportCount') IS NULL
+BEGIN
+    ALTER TABLE dbo.Polls
+        ADD ReportCount INT NOT NULL
+            CONSTRAINT DF_Polls_ReportCount DEFAULT 0;
+END;
+
+IF COL_LENGTH('dbo.Polls', 'LastReportedAt') IS NULL
+BEGIN
+    ALTER TABLE dbo.Polls ADD LastReportedAt DATETIME2 NULL;
+END;
+
+UPDATE dbo.Polls
+SET ModerationStatus = 'Published'
+WHERE ModerationStatus IS NULL OR LTRIM(RTRIM(ModerationStatus)) = '';
+
+IF OBJECT_ID('dbo.PollReports', 'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.PollReports (
+        Id BIGINT IDENTITY(1,1) PRIMARY KEY,
+        PollId BIGINT NOT NULL,
+        ReportedByUserId BIGINT NOT NULL,
+        Reason NVARCHAR(1000) NOT NULL,
+        CreatedAt DATETIME2 NOT NULL CONSTRAINT DF_PollReports_CreatedAt DEFAULT GETUTCDATE(),
+        CONSTRAINT FK_PollReports_Polls FOREIGN KEY (PollId) REFERENCES dbo.Polls(Id),
+        CONSTRAINT FK_PollReports_Users FOREIGN KEY (ReportedByUserId) REFERENCES dbo.Users(Id)
+    );
+END;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE name = 'IX_Polls_ModerationStatus' AND object_id = OBJECT_ID('dbo.Polls')
+)
+BEGIN
+    CREATE INDEX IX_Polls_ModerationStatus
+    ON dbo.Polls (ModerationStatus, IsActive, CreatedAt DESC);
+END;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE name = 'IX_PollReports_PollId' AND object_id = OBJECT_ID('dbo.PollReports')
+)
+BEGIN
+    CREATE INDEX IX_PollReports_PollId ON dbo.PollReports (PollId, CreatedAt DESC);
+END;

--- a/Backend/BackendAPI/Models/Poll.cs
+++ b/Backend/BackendAPI/Models/Poll.cs
@@ -14,6 +14,12 @@ namespace BackendAPI.Models
         public long? CreatedByUserId { get; set; }
         public string? CreatedByUsername { get; set; }
         public string? CreatedByDisplayName { get; set; }
+        public string ModerationStatus { get; set; } = PollModerationStatus.Published;
+        public string? ModerationReason { get; set; }
+        public long? ModeratedByUserId { get; set; }
+        public DateTime? ModeratedAt { get; set; }
+        public int ReportCount { get; set; }
+        public DateTime? LastReportedAt { get; set; }
 
         // ── Ingestion / AI fields (US-01) ────────────────────────────────────
         /// <summary>Origin of the poll: "rss" | "youtube" | "gnews" | "manual"</summary>
@@ -59,6 +65,44 @@ namespace BackendAPI.Models
     }
 
     // ── TrendingTopics staging table model (US-01) ───────────────────────────
+    public static class PollModerationStatus
+    {
+        public const string Draft = "Draft";
+        public const string PendingReview = "PendingReview";
+        public const string Published = "Published";
+        public const string Rejected = "Rejected";
+        public const string Flagged = "Flagged";
+
+        public static readonly HashSet<string> All = new(StringComparer.OrdinalIgnoreCase)
+        {
+            Draft,
+            PendingReview,
+            Published,
+            Rejected,
+            Flagged
+        };
+
+        public static string Normalize(string? status, string fallback = Published)
+        {
+            if (string.IsNullOrWhiteSpace(status)) return fallback;
+
+            return All.TryGetValue(status.Trim(), out var normalized)
+                ? normalized
+                : fallback;
+        }
+    }
+
+    public class ReportPollRequest
+    {
+        public string Reason { get; set; } = string.Empty;
+    }
+
+    public class ModeratePollRequest
+    {
+        public string Status { get; set; } = PollModerationStatus.Published;
+        public string? Reason { get; set; }
+    }
+
     public class TrendingTopic
     {
         public long Id { get; set; }

--- a/Backend/BackendAPI/Repository/PollsRepository.cs
+++ b/Backend/BackendAPI/Repository/PollsRepository.cs
@@ -69,6 +69,7 @@ namespace BackendAPI.Repository
                   LEFT JOIN Users u ON u.Id = p.CreatedByUserId
                   LEFT JOIN PollOptions o ON o.PollId = p.Id
                   WHERE p.IsActive = 1
+                    AND p.ModerationStatus = 'Published'
                     AND (@Category IS NULL OR LOWER(p.Category) = LOWER(@Category))
                   ORDER BY p.CreatedAt DESC",
                 (poll, option) =>
@@ -137,6 +138,7 @@ namespace BackendAPI.Repository
                   LEFT JOIN Users u ON u.Id = p.CreatedByUserId
                   LEFT JOIN PollOptions o ON o.PollId = p.Id
                   WHERE p.IsActive = 1
+                    AND p.ModerationStatus = 'Published'
                     AND (@Category IS NULL OR LOWER(p.Category) = LOWER(@Category))
                   ORDER BY p.TotalVotes DESC, p.CreatedAt DESC",
                 (poll, option) =>
@@ -171,6 +173,7 @@ namespace BackendAPI.Repository
                     SELECT TOP (50) p.*
                     FROM Polls p
                     WHERE p.IsActive = 1
+                      AND p.ModerationStatus = 'Published'
                       AND p.Question LIKE @Search
                       AND (@Category IS NULL OR LOWER(p.Category) = LOWER(@Category))
                     ORDER BY p.TotalVotes DESC, p.CreatedAt DESC
@@ -210,6 +213,7 @@ namespace BackendAPI.Repository
                   LEFT JOIN Users u ON u.Id = p.CreatedByUserId
                   LEFT JOIN PollOptions o ON o.PollId = p.Id
                   WHERE p.IsActive = 1
+                    AND p.ModerationStatus = 'Published'
                   ORDER BY p.CreatedAt DESC",
                 (poll, option) =>
                 {
@@ -231,12 +235,48 @@ namespace BackendAPI.Repository
 
         // ── Create ────────────────────────────────────────────────────────────
 
+        public async Task<IEnumerable<Poll>> GetModerationQueueAsync(string? status = null, int count = 50)
+        {
+            using var conn = _context.CreateConnection();
+            var pollDict = new Dictionary<long, Poll>();
+            var normalizedStatus = string.IsNullOrWhiteSpace(status)
+                ? null
+                : PollModerationStatus.Normalize(status, PollModerationStatus.PendingReview);
+
+            await conn.QueryAsync<Poll, PollOption, Poll>(
+                @"SELECT TOP (@Count) p.*, u.Username AS CreatedByUsername, u.DisplayName AS CreatedByDisplayName, o.*
+                  FROM Polls p
+                  LEFT JOIN Users u ON u.Id = p.CreatedByUserId
+                  LEFT JOIN PollOptions o ON o.PollId = p.Id
+                  WHERE p.IsActive = 1
+                    AND (@Status IS NULL OR p.ModerationStatus = @Status)
+                    AND (@Status IS NOT NULL OR p.ModerationStatus IN ('PendingReview', 'Flagged'))
+                  ORDER BY p.CreatedAt DESC",
+                (poll, option) =>
+                {
+                    if (!pollDict.TryGetValue(poll.Id, out var existing))
+                    {
+                        existing = poll;
+                        existing.Options = new List<PollOption>();
+                        pollDict[poll.Id] = existing;
+                    }
+                    if (option != null) existing.Options.Add(option);
+                    return existing;
+                },
+                new { Count = count, Status = normalizedStatus },
+                splitOn: "Id"
+            );
+
+            return pollDict.Values;
+        }
+
         public async Task<long> CreateAsync(CreatePollRequest request, long? createdByUserId = null)
         {
             using var conn = _context.CreateConnection();
             conn.Open();
             using var transaction = conn.BeginTransaction();
             var normalizedCategory = CategoryCatalog.NormalizeName(request.Category);
+            var moderationStatus = PollModerationStatus.PendingReview;
 
             try
             {
@@ -244,11 +284,13 @@ namespace BackendAPI.Repository
                     @"INSERT INTO Polls
                         (Question, Description, Category, ExpiresAt, IsActive, IsTrending,
                          CreatedByUserId,
-                         CreatedAt, TotalVotes, SourceType, SourceUrl, ThumbnailUrl, IsAIGenerated)
+                         CreatedAt, TotalVotes, SourceType, SourceUrl, ThumbnailUrl, IsAIGenerated,
+                         ModerationStatus, ModerationReason, ModeratedByUserId, ModeratedAt, ReportCount, LastReportedAt)
                       VALUES
                         (@Question, @Description, @Category, @ExpiresAt, 1, 0,
                          @CreatedByUserId,
-                         GETUTCDATE(), 0, @SourceType, @SourceUrl, @ThumbnailUrl, @IsAIGenerated);
+                         GETUTCDATE(), 0, @SourceType, @SourceUrl, @ThumbnailUrl, @IsAIGenerated,
+                         @ModerationStatus, NULL, NULL, NULL, 0, NULL);
                       SELECT CAST(SCOPE_IDENTITY() AS BIGINT);",
                     new
                     {
@@ -260,6 +302,7 @@ namespace BackendAPI.Repository
                         request.SourceUrl,
                         request.ThumbnailUrl,
                         request.IsAIGenerated,
+                        ModerationStatus = moderationStatus,
                         CreatedByUserId = createdByUserId
                     },
                     transaction
@@ -295,6 +338,79 @@ namespace BackendAPI.Repository
 
         // ── Delete ────────────────────────────────────────────────────────────
 
+        public async Task<bool> ReportAsync(long pollId, long reportedByUserId, string reason)
+        {
+            using var conn = _context.CreateConnection();
+            conn.Open();
+            using var transaction = conn.BeginTransaction();
+
+            try
+            {
+                var rows = await conn.ExecuteAsync(
+                    @"UPDATE Polls
+                      SET ModerationStatus = 'Flagged',
+                          ModerationReason = @Reason,
+                          ReportCount = ReportCount + 1,
+                          LastReportedAt = GETUTCDATE()
+                      WHERE Id = @PollId AND IsActive = 1",
+                    new
+                    {
+                        PollId = pollId,
+                        Reason = string.IsNullOrWhiteSpace(reason) ? "Reported by user" : reason.Trim()
+                    },
+                    transaction);
+
+                if (rows == 0)
+                {
+                    transaction.Rollback();
+                    return false;
+                }
+
+                await conn.ExecuteAsync(
+                    @"INSERT INTO PollReports (PollId, ReportedByUserId, Reason, CreatedAt)
+                      VALUES (@PollId, @ReportedByUserId, @Reason, GETUTCDATE())",
+                    new
+                    {
+                        PollId = pollId,
+                        ReportedByUserId = reportedByUserId,
+                        Reason = string.IsNullOrWhiteSpace(reason) ? "Reported by user" : reason.Trim()
+                    },
+                    transaction);
+
+                transaction.Commit();
+                return true;
+            }
+            catch
+            {
+                transaction.Rollback();
+                throw;
+            }
+        }
+
+        public async Task<bool> ModerateAsync(long pollId, string status, string? reason, long moderatedByUserId)
+        {
+            using var conn = _context.CreateConnection();
+            var normalizedStatus = PollModerationStatus.Normalize(status);
+
+            var rows = await conn.ExecuteAsync(
+                @"UPDATE Polls
+                  SET ModerationStatus = @Status,
+                      ModerationReason = @Reason,
+                      ModeratedByUserId = @ModeratedByUserId,
+                      ModeratedAt = GETUTCDATE(),
+                      IsActive = CASE WHEN @Status = 'Rejected' THEN 0 ELSE IsActive END
+                  WHERE Id = @PollId",
+                new
+                {
+                    PollId = pollId,
+                    Status = normalizedStatus,
+                    Reason = string.IsNullOrWhiteSpace(reason) ? null : reason.Trim(),
+                    ModeratedByUserId = moderatedByUserId
+                });
+
+            return rows > 0;
+        }
+
         public async Task<bool> DeleteAsync(long id)
         {
             using var conn = _context.CreateConnection();
@@ -314,7 +430,7 @@ namespace BackendAPI.Repository
                 UPDATE Polls SET IsTrending = 0 WHERE IsActive = 1;
                 UPDATE TOP (10) Polls SET IsTrending = 1
                 FROM Polls
-                WHERE IsActive = 1
+                WHERE IsActive = 1 AND ModerationStatus = 'Published'
                 ORDER BY TotalVotes DESC;
             ");
         }

--- a/Frontend/components/poll-create/index.tsx
+++ b/Frontend/components/poll-create/index.tsx
@@ -90,7 +90,7 @@ export function PollCreator() {
   const isLastStep = currentStep === STEPS.length
   const canGoNext = currentStep === 1 ? draft.question.trim().length > 0 : true
 
-  // Published success state
+  // Submitted success state
   if (isPublished) {
     return (
       <div className="flex min-h-[80vh] flex-col items-center justify-center px-4">
@@ -114,7 +114,7 @@ export function PollCreator() {
           transition={{ delay: 0.3 }}
           className="text-2xl font-bold text-foreground"
         >
-          Poll Published!
+          Poll Submitted!
         </motion.h2>
         <motion.p
           initial={{ opacity: 0, y: 20 }}
@@ -122,7 +122,7 @@ export function PollCreator() {
           transition={{ delay: 0.4 }}
           className="mt-2 text-center text-muted-foreground"
         >
-          Your poll is now live. Redirecting to home...
+          Your poll is in review. Redirecting to home...
         </motion.p>
         
         {/* Confetti-like particles */}

--- a/Frontend/components/poll-detail/poll-detail-card.tsx
+++ b/Frontend/components/poll-detail/poll-detail-card.tsx
@@ -7,6 +7,7 @@ import {
   ArrowLeft,
   CheckCircle2,
   Clock,
+  Flag,
   ImageOff,
   Loader2,
   Newspaper,
@@ -95,8 +96,10 @@ export function PollDetailCard({ pollId }: PollDetailCardProps) {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [voteError, setVoteError] = useState<string | null>(null)
+  const [reportMessage, setReportMessage] = useState<string | null>(null)
   const [authNotice, setAuthNotice] = useState<string | null>(null)
   const [votingOptionId, setVotingOptionId] = useState<number | null>(null)
+  const [isReporting, setIsReporting] = useState(false)
   const [xpAwarded, setXpAwarded] = useState<number | null>(null)
 
   const loadPoll = useCallback(async () => {
@@ -144,6 +147,32 @@ export function PollDetailCard({ pollId }: PollDetailCardProps) {
       setVoteError(err instanceof Error ? err.message : "Could not record your vote")
     } finally {
       setVotingOptionId(null)
+    }
+  }
+
+  async function handleReport() {
+    if (authLoading || !poll || isReporting) return
+
+    if (!isAuthenticated) {
+      setAuthNotice("Sign in to report polls")
+      router.push(
+        `/login?message=${encodeURIComponent("Sign in to report polls")}&redirect=${encodeURIComponent(`/polls/${pollId}`)}`
+      )
+      return
+    }
+
+    setIsReporting(true)
+    setReportMessage(null)
+    try {
+      const response = await pollsApi.report(
+        pollId,
+        "User reported this poll from the poll detail page."
+      )
+      setReportMessage(response.message)
+    } catch (err) {
+      setReportMessage(err instanceof Error ? err.message : "Could not report this poll")
+    } finally {
+      setIsReporting(false)
     }
   }
 
@@ -301,6 +330,12 @@ export function PollDetailCard({ pollId }: PollDetailCardProps) {
             </div>
           )}
 
+          {reportMessage && (
+            <div className="rounded-xl bg-secondary/70 px-4 py-3 text-sm font-medium text-muted-foreground">
+              {reportMessage}
+            </div>
+          )}
+
           {showResults ? (
             <div className="space-y-3">
               {poll.options.map((option) => (
@@ -337,6 +372,24 @@ export function PollDetailCard({ pollId }: PollDetailCardProps) {
               ))}
             </div>
           )}
+
+          <div className="flex justify-end">
+            <Button
+              className="gap-2 text-muted-foreground"
+              disabled={isReporting}
+              onClick={handleReport}
+              size="sm"
+              type="button"
+              variant="ghost"
+            >
+              {isReporting ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Flag className="h-4 w-4" />
+              )}
+              Report
+            </Button>
+          </div>
         </div>
       </article>
     </div>

--- a/Frontend/lib/api.ts
+++ b/Frontend/lib/api.ts
@@ -30,6 +30,12 @@ export interface ApiPoll {
   createdByUserId: number | null
   createdByUsername: string | null
   createdByDisplayName: string | null
+  moderationStatus: "Draft" | "PendingReview" | "Published" | "Rejected" | "Flagged"
+  moderationReason: string | null
+  moderatedByUserId: number | null
+  moderatedAt: string | null
+  reportCount: number
+  lastReportedAt: string | null
   sourceType: string | null
   sourceUrl: string | null
   thumbnailUrl: string | null
@@ -118,6 +124,11 @@ function categoryQuery(category?: string) {
   return category ? `category=${encodeURIComponent(category)}` : ""
 }
 
+export interface ModeratePollPayload {
+  status: ApiPoll["moderationStatus"]
+  reason?: string
+}
+
 export const pollsApi = {
   /** Fetch trending polls for the feed. Includes hasVoted when authenticated. */
   getTrending: (count = 20, category?: string) => {
@@ -146,6 +157,24 @@ export const pollsApi = {
   create: (payload: CreatePollPayload) =>
     request<ApiPoll>("/api/polls", {
       method: "POST",
+      body: JSON.stringify(payload),
+    }),
+
+  report: (id: number | string, reason: string) =>
+    request<{ message: string }>(`/api/polls/${id}/report`, {
+      method: "POST",
+      body: JSON.stringify({ reason }),
+    }),
+
+  getModerationQueue: (status?: ApiPoll["moderationStatus"], count = 50) => {
+    const query = new URLSearchParams({ count: String(count) })
+    if (status) query.set("status", status)
+    return request<ApiPoll[]>(`/api/polls/moderation?${query.toString()}`)
+  },
+
+  moderate: (id: number | string, payload: ModeratePollPayload) =>
+    request<ApiPoll>(`/api/polls/${id}/moderation`, {
+      method: "PATCH",
       body: JSON.stringify(payload),
     }),
 }


### PR DESCRIPTION
## Summary
- add poll moderation status/reason fields plus a poll reports audit table migration
- route newly created user and AI polls into PendingReview and keep public list/search/trending feeds limited to Published polls
- add report, moderation queue, and approve/reject/flag endpoints with configurable reviewer access
- block voting on polls that are not Published
- add frontend report action on poll detail and update create success copy for review flow

## Reviewer access
Reviewer endpoints require auth and one of:
- `Moderation:AllowAuthenticatedReviewers=true` for trusted/dev environments
- `Moderation:ReviewerUserIds` as a comma-separated list of user IDs

## Verification
- `dotnet build` (passes; existing nullable warning remains in `Backend/BackendAPI/Repository/AuthRepository.cs`)
- `./node_modules/.bin/tsc --noEmit`
- `npm run build`
- `git diff --check`
- `npm run lint` is blocked because `eslint` is not installed in the frontend package

Closes #54