### PR TITLE
Add daily challenge rewards

### DIFF
--- a/Backend/BackendAPI/Controllers/ChallengesController.cs
+++ b/Backend/BackendAPI/Controllers/ChallengesController.cs
@@ -1,0 +1,37 @@
+using BackendAPI.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace BackendAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    public class ChallengesController : ControllerBase
+    {
+        private readonly IChallengesRepository _challengesRepo;
+
+        public ChallengesController(IChallengesRepository challengesRepo)
+        {
+            _challengesRepo = challengesRepo;
+        }
+
+        private long? CurrentUserId()
+        {
+            var claim = User.FindFirst(ClaimTypes.NameIdentifier)
+                     ?? User.FindFirst("sub");
+            return claim != null && long.TryParse(claim.Value, out var id) ? id : null;
+        }
+
+        [HttpGet("active")]
+        public async Task<IActionResult> GetActive()
+        {
+            var userId = CurrentUserId();
+            if (userId == null) return Unauthorized(new { message = "Invalid token." });
+
+            var challenges = await _challengesRepo.GetActiveForUserAsync(userId.Value, DateTime.UtcNow);
+            return Ok(challenges);
+        }
+    }
+}

--- a/Backend/BackendAPI/Controllers/VotesController.cs
+++ b/Backend/BackendAPI/Controllers/VotesController.cs
@@ -15,17 +15,20 @@ namespace BackendAPI.Controllers
         private readonly IUsersRepository _usersRepo;
         private readonly IPollsRepository _pollsRepo;
         private readonly INotificationsRepository _notificationsRepo;
+        private readonly IChallengesRepository _challengesRepo;
 
         public VotesController(
             IVotesRepository votesRepo,
             IUsersRepository usersRepo,
             IPollsRepository pollsRepo,
-            INotificationsRepository notificationsRepo)
+            INotificationsRepository notificationsRepo,
+            IChallengesRepository challengesRepo)
         {
             _votesRepo = votesRepo;
             _usersRepo = usersRepo;
             _pollsRepo = pollsRepo;
             _notificationsRepo = notificationsRepo;
+            _challengesRepo = challengesRepo;
         }
 
         // POST /api/votes  (US-15: requires authentication)
@@ -72,6 +75,7 @@ namespace BackendAPI.Controllers
                 userId,
                 GamificationRules.VoteXp(poll),
                 DateTime.UtcNow);
+            var challenges = await _challengesRepo.AdvanceForVoteAsync(userId, poll, DateTime.UtcNow);
 
             if (userBeforeReward != null && userBeforeReward.Xp / 1000 < reward.Xp / 1000)
             {
@@ -101,7 +105,8 @@ namespace BackendAPI.Controllers
             return Ok(new CastVoteResponse
             {
                 Poll = updated!,
-                Reward = reward
+                Reward = reward,
+                Challenges = challenges
             });
         }
 

--- a/Backend/BackendAPI/Interfaces/IChallengesRepository.cs
+++ b/Backend/BackendAPI/Interfaces/IChallengesRepository.cs
@@ -1,0 +1,11 @@
+using BackendAPI.Models;
+
+namespace BackendAPI.Interfaces
+{
+    public interface IChallengesRepository
+    {
+        Task EnsureDailyChallengeAsync(DateTime utcNow);
+        Task<IEnumerable<UserChallenge>> GetActiveForUserAsync(long userId, DateTime utcNow);
+        Task<IEnumerable<UserChallenge>> AdvanceForVoteAsync(long userId, Poll poll, DateTime utcNow);
+    }
+}

--- a/Backend/BackendAPI/Migrations/US55_Challenges.sql
+++ b/Backend/BackendAPI/Migrations/US55_Challenges.sql
@@ -1,0 +1,67 @@
+IF OBJECT_ID('dbo.Challenges', 'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.Challenges (
+        Id BIGINT IDENTITY(1,1) PRIMARY KEY,
+        Title NVARCHAR(160) NOT NULL,
+        Category NVARCHAR(100) NULL,
+        RequiredVotes INT NOT NULL,
+        RewardXp INT NOT NULL,
+        RewardBadge NVARCHAR(120) NULL,
+        StartAt DATETIME2 NOT NULL,
+        EndAt DATETIME2 NOT NULL,
+        IsActive BIT NOT NULL CONSTRAINT DF_Challenges_IsActive DEFAULT 1,
+        CreatedAt DATETIME2 NOT NULL CONSTRAINT DF_Challenges_CreatedAt DEFAULT GETUTCDATE()
+    );
+END;
+
+IF OBJECT_ID('dbo.UserChallengeProgress', 'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.UserChallengeProgress (
+        Id BIGINT IDENTITY(1,1) PRIMARY KEY,
+        UserId BIGINT NOT NULL,
+        ChallengeId BIGINT NOT NULL,
+        CurrentVotes INT NOT NULL CONSTRAINT DF_UserChallengeProgress_CurrentVotes DEFAULT 0,
+        IsCompleted BIT NOT NULL CONSTRAINT DF_UserChallengeProgress_IsCompleted DEFAULT 0,
+        RewardGranted BIT NOT NULL CONSTRAINT DF_UserChallengeProgress_RewardGranted DEFAULT 0,
+        CompletedAt DATETIME2 NULL,
+        CreatedAt DATETIME2 NOT NULL CONSTRAINT DF_UserChallengeProgress_CreatedAt DEFAULT GETUTCDATE(),
+        UpdatedAt DATETIME2 NOT NULL CONSTRAINT DF_UserChallengeProgress_UpdatedAt DEFAULT GETUTCDATE(),
+        CONSTRAINT FK_UserChallengeProgress_Users FOREIGN KEY (UserId) REFERENCES dbo.Users(Id),
+        CONSTRAINT FK_UserChallengeProgress_Challenges FOREIGN KEY (ChallengeId) REFERENCES dbo.Challenges(Id),
+        CONSTRAINT UQ_UserChallengeProgress_UserChallenge UNIQUE (UserId, ChallengeId)
+    );
+END;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE name = 'IX_Challenges_ActiveWindow' AND object_id = OBJECT_ID('dbo.Challenges')
+)
+BEGIN
+    CREATE INDEX IX_Challenges_ActiveWindow
+    ON dbo.Challenges (IsActive, StartAt, EndAt, Category);
+END;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE name = 'IX_UserChallengeProgress_User' AND object_id = OBJECT_ID('dbo.UserChallengeProgress')
+)
+BEGIN
+    CREATE INDEX IX_UserChallengeProgress_User
+    ON dbo.UserChallengeProgress (UserId, IsCompleted, UpdatedAt DESC);
+END;
+
+DECLARE @Today DATETIME2 = CONVERT(date, GETUTCDATE());
+DECLARE @Tomorrow DATETIME2 = DATEADD(day, 1, @Today);
+
+IF NOT EXISTS (
+    SELECT 1 FROM dbo.Challenges
+    WHERE Title = 'Daily Pulse'
+      AND StartAt = @Today
+      AND EndAt = @Tomorrow
+)
+BEGIN
+    INSERT INTO dbo.Challenges
+        (Title, Category, RequiredVotes, RewardXp, RewardBadge, StartAt, EndAt, IsActive, CreatedAt)
+    VALUES
+        ('Daily Pulse', NULL, 3, 75, 'Daily Voter', @Today, @Tomorrow, 1, GETUTCDATE());
+END;

--- a/Backend/BackendAPI/Models/Challenge.cs
+++ b/Backend/BackendAPI/Models/Challenge.cs
@@ -1,0 +1,32 @@
+namespace BackendAPI.Models
+{
+    public class Challenge
+    {
+        public long Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public string? Category { get; set; }
+        public int RequiredVotes { get; set; }
+        public int RewardXp { get; set; }
+        public string? RewardBadge { get; set; }
+        public DateTime StartAt { get; set; }
+        public DateTime EndAt { get; set; }
+        public bool IsActive { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+
+    public class UserChallenge
+    {
+        public long ChallengeId { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public string? Category { get; set; }
+        public int RequiredVotes { get; set; }
+        public int RewardXp { get; set; }
+        public string? RewardBadge { get; set; }
+        public DateTime StartAt { get; set; }
+        public DateTime EndAt { get; set; }
+        public int CurrentVotes { get; set; }
+        public bool IsCompleted { get; set; }
+        public bool RewardGranted { get; set; }
+        public DateTime? CompletedAt { get; set; }
+    }
+}

--- a/Backend/BackendAPI/Models/Vote.cs
+++ b/Backend/BackendAPI/Models/Vote.cs
@@ -20,5 +20,6 @@ namespace BackendAPI.Models
     {
         public Poll Poll { get; set; } = new();
         public VoteRewardResult Reward { get; set; } = new();
+        public IEnumerable<UserChallenge> Challenges { get; set; } = Enumerable.Empty<UserChallenge>();
     }
 }

--- a/Backend/BackendAPI/Program.cs
+++ b/Backend/BackendAPI/Program.cs
@@ -60,6 +60,7 @@ builder.Services.AddScoped<IUsersRepository,         UsersRepository>();
 builder.Services.AddScoped<INotificationsRepository, NotificationsRepository>();
 builder.Services.AddScoped<IDashboardRepository,     DashboardRepository>();
 builder.Services.AddScoped<ITrendingTopicRepository, TrendingTopicRepository>();
+builder.Services.AddScoped<IChallengesRepository,    ChallengesRepository>();
 
 // ── Ingestion Services (US-03, US-04, US-05) ──────────────────────────────
 builder.Services.AddHttpClient();

--- a/Backend/BackendAPI/Repository/ChallengesRepository.cs
+++ b/Backend/BackendAPI/Repository/ChallengesRepository.cs
@@ -1,0 +1,185 @@
+using BackendAPI.Data;
+using BackendAPI.Interfaces;
+using BackendAPI.Models;
+using Dapper;
+
+namespace BackendAPI.Repository
+{
+    public class ChallengesRepository : IChallengesRepository
+    {
+        private readonly DapperContext _context;
+
+        public ChallengesRepository(DapperContext context)
+        {
+            _context = context;
+        }
+
+        public async Task EnsureDailyChallengeAsync(DateTime utcNow)
+        {
+            using var conn = _context.CreateConnection();
+            var start = utcNow.Date;
+            var end = start.AddDays(1);
+
+            var exists = await conn.ExecuteScalarAsync<int>(
+                @"SELECT COUNT(1)
+                  FROM Challenges
+                  WHERE StartAt = @StartAt
+                    AND EndAt = @EndAt
+                    AND Title = @Title",
+                new { StartAt = start, EndAt = end, Title = "Daily Pulse" });
+
+            if (exists > 0) return;
+
+            await conn.ExecuteAsync(
+                @"INSERT INTO Challenges
+                    (Title, Category, RequiredVotes, RewardXp, RewardBadge, StartAt, EndAt, IsActive, CreatedAt)
+                  VALUES
+                    (@Title, NULL, 3, 75, @RewardBadge, @StartAt, @EndAt, 1, GETUTCDATE())",
+                new
+                {
+                    Title = "Daily Pulse",
+                    RewardBadge = "Daily Voter",
+                    StartAt = start,
+                    EndAt = end
+                });
+        }
+
+        public async Task<IEnumerable<UserChallenge>> GetActiveForUserAsync(long userId, DateTime utcNow)
+        {
+            await EnsureDailyChallengeAsync(utcNow);
+
+            using var conn = _context.CreateConnection();
+            return await conn.QueryAsync<UserChallenge>(
+                @"SELECT
+                      c.Id AS ChallengeId,
+                      c.Title,
+                      c.Category,
+                      c.RequiredVotes,
+                      c.RewardXp,
+                      c.RewardBadge,
+                      c.StartAt,
+                      c.EndAt,
+                      COALESCE(uc.CurrentVotes, 0) AS CurrentVotes,
+                      CAST(COALESCE(uc.IsCompleted, 0) AS bit) AS IsCompleted,
+                      CAST(COALESCE(uc.RewardGranted, 0) AS bit) AS RewardGranted,
+                      uc.CompletedAt
+                  FROM Challenges c
+                  LEFT JOIN UserChallengeProgress uc
+                    ON uc.ChallengeId = c.Id AND uc.UserId = @UserId
+                  WHERE c.IsActive = 1
+                    AND c.StartAt <= @UtcNow
+                    AND c.EndAt > @UtcNow
+                  ORDER BY c.EndAt ASC, c.Id ASC",
+                new { UserId = userId, UtcNow = utcNow });
+        }
+
+        public async Task<IEnumerable<UserChallenge>> AdvanceForVoteAsync(long userId, Poll poll, DateTime utcNow)
+        {
+            await EnsureDailyChallengeAsync(utcNow);
+
+            using var conn = _context.CreateConnection();
+            conn.Open();
+            using var transaction = conn.BeginTransaction();
+
+            try
+            {
+                var challenges = (await conn.QueryAsync<Challenge>(
+                    @"SELECT *
+                      FROM Challenges
+                      WHERE IsActive = 1
+                        AND StartAt <= @UtcNow
+                        AND EndAt > @UtcNow
+                        AND (Category IS NULL OR LOWER(Category) = LOWER(@Category))",
+                    new { UtcNow = utcNow, poll.Category },
+                    transaction)).ToList();
+
+                foreach (var challenge in challenges)
+                {
+                    await conn.ExecuteAsync(
+                        @"IF NOT EXISTS (
+                              SELECT 1 FROM UserChallengeProgress
+                              WHERE UserId = @UserId AND ChallengeId = @ChallengeId
+                          )
+                          BEGIN
+                              INSERT INTO UserChallengeProgress
+                                  (UserId, ChallengeId, CurrentVotes, IsCompleted, RewardGranted, CreatedAt, UpdatedAt)
+                              VALUES
+                                  (@UserId, @ChallengeId, 0, 0, 0, GETUTCDATE(), GETUTCDATE())
+                          END",
+                        new { UserId = userId, ChallengeId = challenge.Id },
+                        transaction);
+
+                    var progress = await conn.QuerySingleAsync<UserChallenge>(
+                        @"UPDATE UserChallengeProgress
+                          SET CurrentVotes = CASE
+                                  WHEN IsCompleted = 1 THEN CurrentVotes
+                                  ELSE CASE
+                                      WHEN CurrentVotes + 1 > @RequiredVotes THEN @RequiredVotes
+                                      ELSE CurrentVotes + 1
+                                  END
+                              END,
+                              IsCompleted = CASE
+                                  WHEN IsCompleted = 1 OR CurrentVotes + 1 >= @RequiredVotes THEN 1
+                                  ELSE 0
+                              END,
+                              CompletedAt = CASE
+                                  WHEN CompletedAt IS NULL AND CurrentVotes + 1 >= @RequiredVotes THEN GETUTCDATE()
+                                  ELSE CompletedAt
+                              END,
+                              UpdatedAt = GETUTCDATE()
+                          OUTPUT
+                              inserted.ChallengeId,
+                              @Title AS Title,
+                              @Category AS Category,
+                              @RequiredVotes AS RequiredVotes,
+                              @RewardXp AS RewardXp,
+                              @RewardBadge AS RewardBadge,
+                              @StartAt AS StartAt,
+                              @EndAt AS EndAt,
+                              inserted.CurrentVotes,
+                              inserted.IsCompleted,
+                              inserted.RewardGranted,
+                              inserted.CompletedAt
+                          WHERE UserId = @UserId AND ChallengeId = @ChallengeId",
+                        new
+                        {
+                            UserId = userId,
+                            ChallengeId = challenge.Id,
+                            challenge.Title,
+                            challenge.Category,
+                            challenge.RequiredVotes,
+                            challenge.RewardXp,
+                            challenge.RewardBadge,
+                            challenge.StartAt,
+                            challenge.EndAt
+                        },
+                        transaction);
+
+                    if (progress.IsCompleted && !progress.RewardGranted)
+                    {
+                        await conn.ExecuteAsync(
+                            "UPDATE Users SET Xp = Xp + @RewardXp WHERE Id = @UserId",
+                            new { UserId = userId, challenge.RewardXp },
+                            transaction);
+
+                        await conn.ExecuteAsync(
+                            @"UPDATE UserChallengeProgress
+                              SET RewardGranted = 1, UpdatedAt = GETUTCDATE()
+                              WHERE UserId = @UserId AND ChallengeId = @ChallengeId",
+                            new { UserId = userId, ChallengeId = challenge.Id },
+                            transaction);
+                    }
+                }
+
+                transaction.Commit();
+            }
+            catch
+            {
+                transaction.Rollback();
+                throw;
+            }
+
+            return await GetActiveForUserAsync(userId, utcNow);
+        }
+    }
+}

--- a/Frontend/app/page.tsx
+++ b/Frontend/app/page.tsx
@@ -2,13 +2,13 @@
 
 import { useEffect, useState } from "react"
 import Link from "next/link"
-import { BarChart3, ChevronRight, Clock, Loader2, Plus, TrendingUp, Trophy, Users, Zap } from "lucide-react"
+import { BarChart3, ChevronRight, Clock, Loader2, Plus, Target, TrendingUp, Trophy, Users, Zap } from "lucide-react"
 import { motion } from "framer-motion"
 import { AppShell } from "@/components/app-shell"
 import { CategoryBadge } from "@/components/category-badge"
 import { Button } from "@/components/ui/button"
 import { useAuth } from "@/contexts/auth-context"
-import { pollsApi, type ApiPoll } from "@/lib/api"
+import { challengesApi, pollsApi, type ApiChallenge, type ApiPoll } from "@/lib/api"
 
 function timeLeft(iso: string) {
   const diff = new Date(iso).getTime() - Date.now()
@@ -23,6 +23,7 @@ function timeLeft(iso: string) {
 export default function HomePage() {
   const { user, isAuthenticated, isLoading: authLoading } = useAuth()
   const [polls, setPolls] = useState<ApiPoll[]>([])
+  const [challenges, setChallenges] = useState<ApiChallenge[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -34,6 +35,17 @@ export default function HomePage() {
       .catch((err: Error) => setError(err.message))
       .finally(() => setLoading(false))
   }, [])
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setChallenges([])
+      return
+    }
+
+    challengesApi.getActive()
+      .then(setChallenges)
+      .catch(() => setChallenges([]))
+  }, [isAuthenticated])
 
   const displayName = isAuthenticated ? user?.displayName ?? user?.username : "there"
   const stats = [
@@ -57,6 +69,57 @@ export default function HomePage() {
             {isAuthenticated ? "Your live activity is ready." : "Sign in to track XP, streaks, and poll history."}
           </p>
         </motion.div>
+
+        {isAuthenticated && challenges.length > 0 && (
+          <motion.div
+            animate={{ opacity: 1, y: 0 }}
+            className="mb-6 space-y-3"
+            initial={{ opacity: 0, y: 20 }}
+            transition={{ delay: 0.15 }}
+          >
+            <div className="flex items-center gap-2">
+              <Target className="h-5 w-5 text-primary" />
+              <h2 className="text-lg font-semibold text-foreground">Daily Challenges</h2>
+            </div>
+
+            {challenges.map((challenge) => {
+              const progress = Math.min(100, Math.round((challenge.currentVotes / challenge.requiredVotes) * 100))
+              const remaining = Math.max(0, challenge.requiredVotes - challenge.currentVotes)
+
+              return (
+                <div
+                  className="rounded-2xl bg-card p-4 shadow-sm ring-1 ring-border/50"
+                  key={challenge.challengeId}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="font-semibold text-foreground">{challenge.title}</p>
+                      <p className="mt-1 text-sm text-muted-foreground">
+                        {challenge.isCompleted
+                          ? `Completed. +${challenge.rewardXp} XP earned.`
+                          : `${remaining} more vote${remaining === 1 ? "" : "s"} for +${challenge.rewardXp} XP`}
+                      </p>
+                    </div>
+                    {challenge.rewardBadge && (
+                      <span className="rounded-full bg-amber-500/10 px-2.5 py-1 text-xs font-semibold text-amber-600 dark:text-amber-400">
+                        {challenge.rewardBadge}
+                      </span>
+                    )}
+                  </div>
+                  <div className="mt-3 h-2.5 overflow-hidden rounded-full bg-secondary">
+                    <div
+                      className="h-full rounded-full bg-primary transition-all"
+                      style={{ width: `${progress}%` }}
+                    />
+                  </div>
+                  <div className="mt-2 text-xs text-muted-foreground">
+                    {challenge.currentVotes}/{challenge.requiredVotes} votes today
+                  </div>
+                </div>
+              )
+            })}
+          </motion.div>
+        )}
 
         <motion.div
           animate={{ opacity: 1, y: 0 }}

--- a/Frontend/lib/api.ts
+++ b/Frontend/lib/api.ts
@@ -63,6 +63,22 @@ export interface ApiVoteReward {
 export interface ApiCastVoteResponse {
   poll: ApiPoll
   reward: ApiVoteReward
+  challenges: ApiChallenge[]
+}
+
+export interface ApiChallenge {
+  challengeId: number
+  title: string
+  category: string | null
+  requiredVotes: number
+  rewardXp: number
+  rewardBadge: string | null
+  startAt: string
+  endAt: string
+  currentVotes: number
+  isCompleted: boolean
+  rewardGranted: boolean
+  completedAt: string | null
 }
 
 export interface ApiNotification {
@@ -218,6 +234,10 @@ export const notificationsApi = {
 }
 
 // ── User endpoints ────────────────────────────────────────────────────────────
+
+export const challengesApi = {
+  getActive: () => request<ApiChallenge[]>("/api/challenges/active"),
+}
 
 export interface ApiUser {
   id: number


### PR DESCRIPTION
## Summary
- add challenge and user challenge progress tables with an idempotent daily challenge seed
- add authenticated `/api/challenges/active` endpoint for current challenge progress
- advance matching active challenges only after a successful unique vote and grant challenge XP once
- include challenge progress in vote responses
- show active daily challenge progress on the web home page

## Verification
- `dotnet build` (passes; existing nullable warning remains in `Backend/BackendAPI/Repository/AuthRepository.cs`)
- `./node_modules/.bin/tsc --noEmit`
- `npm run build`
- `git diff --check`
- `npm run lint` is blocked because `eslint` is not installed in the frontend package

Closes #55