### PR TITLE
Personalize poll feed by preferences

### DIFF
--- a/Backend/BackendAPI/Controllers/PollsController.cs
+++ b/Backend/BackendAPI/Controllers/PollsController.cs
@@ -58,6 +58,19 @@ namespace BackendAPI.Controllers
             return Ok(polls);
         }
 
+        // GET /api/polls/personalized
+        [HttpGet("personalized")]
+        public async Task<IActionResult> GetPersonalized(
+            [FromQuery] int count = 20,
+            [FromQuery] string? category = null)
+        {
+            var polls = await _pollsRepo.GetPersonalizedAsync(
+                CurrentUserId(),
+                Math.Clamp(count, 1, 50),
+                category);
+            return Ok(polls);
+        }
+
         // GET /api/polls/search?q=keyword
         [HttpGet("search")]
         public async Task<IActionResult> Search(

--- a/Backend/BackendAPI/Controllers/UsersController.cs
+++ b/Backend/BackendAPI/Controllers/UsersController.cs
@@ -53,6 +53,45 @@ namespace BackendAPI.Controllers
             return Ok(history);
         }
 
+        // GET /api/users/me/preferences/categories
+        [HttpGet("me/preferences/categories")]
+        [Authorize]
+        public async Task<IActionResult> GetMyCategoryPreferences()
+        {
+            var userId = CurrentUserId();
+            if (userId == null) return Unauthorized();
+
+            var preferences = await _usersRepo.GetCategoryPreferencesAsync(userId.Value);
+            return Ok(preferences);
+        }
+
+        // PUT /api/users/me/preferences/categories
+        [HttpPut("me/preferences/categories")]
+        [Authorize]
+        public async Task<IActionResult> UpdateMyCategoryPreferences(
+            [FromBody] UpdateCategoryPreferencesRequest request)
+        {
+            var userId = CurrentUserId();
+            if (userId == null) return Unauthorized();
+
+            var preferences = await _usersRepo.ReplaceCategoryPreferencesAsync(
+                userId.Value,
+                request.Categories);
+            return Ok(preferences);
+        }
+
+        // DELETE /api/users/me/preferences/categories
+        [HttpDelete("me/preferences/categories")]
+        [Authorize]
+        public async Task<IActionResult> ResetMyCategoryPreferences()
+        {
+            var userId = CurrentUserId();
+            if (userId == null) return Unauthorized();
+
+            await _usersRepo.ResetCategoryPreferencesAsync(userId.Value);
+            return NoContent();
+        }
+
         // POST /api/users
         [HttpPost]
         public async Task<IActionResult> Create([FromBody] CreateUserRequest request)

--- a/Backend/BackendAPI/Interfaces/IPollsRepository.cs
+++ b/Backend/BackendAPI/Interfaces/IPollsRepository.cs
@@ -8,6 +8,7 @@ namespace BackendAPI.Interfaces
         Task<IEnumerable<Poll>> GetAllAsync(long? userId = null, string? category = null);
         Task<Poll?> GetByIdAsync(long id, long? userId = null);
         Task<IEnumerable<Poll>> GetTrendingAsync(int count = 10, long? userId = null, string? category = null);
+        Task<IEnumerable<Poll>> GetPersonalizedAsync(long? userId = null, int count = 20, string? category = null);
         Task<IEnumerable<Poll>> SearchAsync(string query, string? category = null, long? userId = null);
         Task<IEnumerable<Poll>> GetRecentAsync(int count = 10);
         Task<IEnumerable<Poll>> GetModerationQueueAsync(string? status = null, int count = 50);

--- a/Backend/BackendAPI/Interfaces/IUsersRepository.cs
+++ b/Backend/BackendAPI/Interfaces/IUsersRepository.cs
@@ -11,5 +11,8 @@ namespace BackendAPI.Interfaces
         Task<VoteRewardResult> ApplyVoteRewardAsync(long userId, int xpToAdd, DateTime utcNow);
         /// <summary>US-22: Returns the user's vote history with poll details.</summary>
         Task<IEnumerable<VoteHistoryItem>> GetVoteHistoryAsync(long userId, int count = 20);
+        Task<IEnumerable<UserCategoryPreference>> GetCategoryPreferencesAsync(long userId);
+        Task<IEnumerable<UserCategoryPreference>> ReplaceCategoryPreferencesAsync(long userId, IEnumerable<string> categories);
+        Task ResetCategoryPreferencesAsync(long userId);
     }
 }

--- a/Backend/BackendAPI/Migrations/US56_User_Category_Preferences.sql
+++ b/Backend/BackendAPI/Migrations/US56_User_Category_Preferences.sql
@@ -1,0 +1,20 @@
+IF OBJECT_ID('dbo.UserCategoryPreferences', 'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.UserCategoryPreferences (
+        Id BIGINT IDENTITY(1,1) PRIMARY KEY,
+        UserId BIGINT NOT NULL,
+        Category NVARCHAR(100) NOT NULL,
+        CreatedAt DATETIME2 NOT NULL CONSTRAINT DF_UserCategoryPreferences_CreatedAt DEFAULT GETUTCDATE(),
+        CONSTRAINT FK_UserCategoryPreferences_Users FOREIGN KEY (UserId) REFERENCES dbo.Users(Id),
+        CONSTRAINT UQ_UserCategoryPreferences_UserCategory UNIQUE (UserId, Category)
+    );
+END;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE name = 'IX_UserCategoryPreferences_UserId' AND object_id = OBJECT_ID('dbo.UserCategoryPreferences')
+)
+BEGIN
+    CREATE INDEX IX_UserCategoryPreferences_UserId
+    ON dbo.UserCategoryPreferences (UserId, Category);
+END;

--- a/Backend/BackendAPI/Models/User.cs
+++ b/Backend/BackendAPI/Models/User.cs
@@ -39,4 +39,16 @@ namespace BackendAPI.Models
         public bool StreakAdvanced { get; set; }
         public DateTime? LastVoteDate { get; set; }
     }
+
+    public class UserCategoryPreference
+    {
+        public string Category { get; set; } = string.Empty;
+        public bool IsExplicit { get; set; }
+        public int VoteCount { get; set; }
+    }
+
+    public class UpdateCategoryPreferencesRequest
+    {
+        public List<string> Categories { get; set; } = new();
+    }
 }

--- a/Backend/BackendAPI/Repository/PollsRepository.cs
+++ b/Backend/BackendAPI/Repository/PollsRepository.cs
@@ -162,6 +162,75 @@ namespace BackendAPI.Repository
 
         // ── GetRecent ─────────────────────────────────────────────────────────
 
+        public async Task<IEnumerable<Poll>> GetPersonalizedAsync(
+            long? userId = null,
+            int count = 20,
+            string? category = null)
+        {
+            if (userId == null)
+            {
+                return await GetTrendingAsync(count, null, category);
+            }
+
+            using var conn = _context.CreateConnection();
+            var pollDict = new Dictionary<long, Poll>();
+            var normalizedCategory = NormalizeFilterCategory(category);
+
+            await conn.QueryAsync<Poll, PollOption, Poll>(
+                @"WITH Activity AS (
+                    SELECT p.Category, COUNT_BIG(*) AS VoteCount
+                    FROM Votes v
+                    JOIN Polls p ON p.Id = v.PollId
+                    WHERE v.UserId = @UserId
+                      AND p.Category <> 'Health'
+                    GROUP BY p.Category
+                  ),
+                  RankedPolls AS (
+                    SELECT TOP (@Count)
+                      p.*,
+                      CAST(
+                        CASE WHEN pref.Category IS NOT NULL THEN 100 ELSE 0 END
+                        + CASE WHEN activity.Category IS NOT NULL THEN
+                            CASE WHEN activity.VoteCount > 10 THEN 50 ELSE activity.VoteCount * 5 END
+                          ELSE 0 END
+                        + CASE WHEN p.IsTrending = 1 THEN 20 ELSE 0 END
+                        + CASE WHEN p.CreatedAt >= DATEADD(day, -2, GETUTCDATE()) THEN 10 ELSE 0 END
+                        AS int
+                      ) AS PersonalizationScore
+                    FROM Polls p
+                    LEFT JOIN UserCategoryPreferences pref
+                      ON pref.UserId = @UserId AND LOWER(pref.Category) = LOWER(p.Category)
+                    LEFT JOIN Activity activity
+                      ON LOWER(activity.Category) = LOWER(p.Category)
+                    WHERE p.IsActive = 1
+                      AND p.ModerationStatus = 'Published'
+                      AND (@Category IS NULL OR LOWER(p.Category) = LOWER(@Category))
+                    ORDER BY PersonalizationScore DESC, p.TotalVotes DESC, p.CreatedAt DESC
+                  )
+                  SELECT rp.*, u.Username AS CreatedByUsername, u.DisplayName AS CreatedByDisplayName, o.*
+                  FROM RankedPolls rp
+                  LEFT JOIN Users u ON u.Id = rp.CreatedByUserId
+                  LEFT JOIN PollOptions o ON o.PollId = rp.Id
+                  ORDER BY rp.PersonalizationScore DESC, rp.TotalVotes DESC, rp.CreatedAt DESC",
+                (poll, option) =>
+                {
+                    if (!pollDict.TryGetValue(poll.Id, out var existing))
+                    {
+                        existing = poll;
+                        existing.Options = new List<PollOption>();
+                        pollDict[poll.Id] = existing;
+                    }
+                    if (option != null) existing.Options.Add(option);
+                    return existing;
+                },
+                new { UserId = userId.Value, Count = count, Category = normalizedCategory },
+                splitOn: "Id"
+            );
+
+            var userVotes = await GetUserVotesAsync(userId);
+            return ApplyVoteState(pollDict.Values, userVotes);
+        }
+
         public async Task<IEnumerable<Poll>> SearchAsync(string query, string? category = null, long? userId = null)
         {
             using var conn = _context.CreateConnection();

--- a/Backend/BackendAPI/Repository/UsersRepository.cs
+++ b/Backend/BackendAPI/Repository/UsersRepository.cs
@@ -120,5 +120,73 @@ namespace BackendAPI.Repository
                 new { UserId = userId, Count = count }
             );
         }
+
+        public async Task<IEnumerable<UserCategoryPreference>> GetCategoryPreferencesAsync(long userId)
+        {
+            using var conn = _context.CreateConnection();
+            return await conn.QueryAsync<UserCategoryPreference>(
+                @"WITH ExplicitPrefs AS (
+                    SELECT Category
+                    FROM UserCategoryPreferences
+                    WHERE UserId = @UserId
+                  ),
+                  Activity AS (
+                    SELECT p.Category, COUNT_BIG(*) AS VoteCount
+                    FROM Votes v
+                    JOIN Polls p ON p.Id = v.PollId
+                    WHERE v.UserId = @UserId
+                      AND p.Category <> 'Health'
+                    GROUP BY p.Category
+                  )
+                  SELECT
+                    COALESCE(pref.Category, activity.Category) AS Category,
+                    CAST(CASE WHEN pref.Category IS NULL THEN 0 ELSE 1 END AS bit) AS IsExplicit,
+                    CAST(COALESCE(activity.VoteCount, 0) AS int) AS VoteCount
+                  FROM ExplicitPrefs pref
+                  FULL OUTER JOIN Activity activity ON LOWER(activity.Category) = LOWER(pref.Category)
+                  ORDER BY IsExplicit DESC, VoteCount DESC, Category ASC",
+                new { UserId = userId });
+        }
+
+        public async Task<IEnumerable<UserCategoryPreference>> ReplaceCategoryPreferencesAsync(
+            long userId,
+            IEnumerable<string> categories)
+        {
+            var normalized = categories
+                .Select(CategoryCatalog.NormalizeName)
+                .Where(category => !category.Equals("Health", StringComparison.OrdinalIgnoreCase))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Take(8)
+                .ToList();
+
+            using var conn = _context.CreateConnection();
+            conn.Open();
+            using var transaction = conn.BeginTransaction();
+
+            await conn.ExecuteAsync(
+                "DELETE FROM UserCategoryPreferences WHERE UserId = @UserId",
+                new { UserId = userId },
+                transaction);
+
+            foreach (var category in normalized)
+            {
+                await conn.ExecuteAsync(
+                    @"INSERT INTO UserCategoryPreferences (UserId, Category, CreatedAt)
+                      VALUES (@UserId, @Category, GETUTCDATE())",
+                    new { UserId = userId, Category = category },
+                    transaction);
+            }
+
+            transaction.Commit();
+            return await GetCategoryPreferencesAsync(userId);
+        }
+
+        public async Task ResetCategoryPreferencesAsync(long userId)
+        {
+            using var conn = _context.CreateConnection();
+            await conn.ExecuteAsync(
+                "DELETE FROM UserCategoryPreferences WHERE UserId = @UserId",
+                new { UserId = userId });
+        }
     }
 }

--- a/Frontend/app/page.tsx
+++ b/Frontend/app/page.tsx
@@ -2,13 +2,15 @@
 
 import { useEffect, useState } from "react"
 import Link from "next/link"
-import { BarChart3, ChevronRight, Clock, Loader2, Plus, TrendingUp, Trophy, Users, Zap } from "lucide-react"
+import { BarChart3, Check, ChevronRight, Clock, Loader2, Plus, RefreshCw, SlidersHorizontal, TrendingUp, Trophy, Users, Zap } from "lucide-react"
 import { motion } from "framer-motion"
 import { AppShell } from "@/components/app-shell"
 import { CategoryBadge } from "@/components/category-badge"
 import { Button } from "@/components/ui/button"
 import { useAuth } from "@/contexts/auth-context"
-import { pollsApi, type ApiPoll } from "@/lib/api"
+import { cn } from "@/lib/utils"
+import { POLL_CATEGORIES } from "@/lib/categories"
+import { pollsApi, usersApi, type ApiPoll } from "@/lib/api"
 
 function timeLeft(iso: string) {
   const diff = new Date(iso).getTime() - Date.now()
@@ -25,6 +27,8 @@ export default function HomePage() {
   const [polls, setPolls] = useState<ApiPoll[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [preferredCategories, setPreferredCategories] = useState<string[]>([])
+  const [savingPreferences, setSavingPreferences] = useState(false)
 
   useEffect(() => {
     setLoading(true)
@@ -34,6 +38,48 @@ export default function HomePage() {
       .catch((err: Error) => setError(err.message))
       .finally(() => setLoading(false))
   }, [])
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setPreferredCategories([])
+      return
+    }
+
+    usersApi.getCategoryPreferences()
+      .then((preferences) => {
+        setPreferredCategories(
+          preferences.filter((preference) => preference.isExplicit).map((preference) => preference.category)
+        )
+      })
+      .catch(() => setPreferredCategories([]))
+  }, [isAuthenticated])
+
+  async function togglePreference(category: string) {
+    const next = preferredCategories.includes(category)
+      ? preferredCategories.filter((item) => item !== category)
+      : [...preferredCategories, category]
+
+    setPreferredCategories(next)
+    setSavingPreferences(true)
+    try {
+      const preferences = await usersApi.updateCategoryPreferences(next)
+      setPreferredCategories(
+        preferences.filter((preference) => preference.isExplicit).map((preference) => preference.category)
+      )
+    } finally {
+      setSavingPreferences(false)
+    }
+  }
+
+  async function resetPreferences() {
+    setSavingPreferences(true)
+    try {
+      await usersApi.resetCategoryPreferences()
+      setPreferredCategories([])
+    } finally {
+      setSavingPreferences(false)
+    }
+  }
 
   const displayName = isAuthenticated ? user?.displayName ?? user?.username : "there"
   const stats = [
@@ -57,6 +103,57 @@ export default function HomePage() {
             {isAuthenticated ? "Your live activity is ready." : "Sign in to track XP, streaks, and poll history."}
           </p>
         </motion.div>
+
+        {isAuthenticated && (
+          <motion.div
+            animate={{ opacity: 1, y: 0 }}
+            className="mb-6 rounded-2xl bg-card p-4 shadow-sm ring-1 ring-border/50"
+            initial={{ opacity: 0, y: 20 }}
+            transition={{ delay: 0.08 }}
+          >
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <SlidersHorizontal className="h-5 w-5 text-primary" />
+                <h2 className="text-lg font-semibold text-foreground">Feed Preferences</h2>
+              </div>
+              <Button
+                className="gap-2 text-muted-foreground"
+                disabled={savingPreferences || preferredCategories.length === 0}
+                onClick={resetPreferences}
+                size="sm"
+                type="button"
+                variant="ghost"
+              >
+                <RefreshCw className="h-4 w-4" />
+                Reset
+              </Button>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              {POLL_CATEGORIES.filter((category) => category.name !== "Health").map((category) => {
+                const selected = preferredCategories.includes(category.name)
+
+                return (
+                  <button
+                    className={cn(
+                      "inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-semibold ring-1 transition-colors",
+                      selected
+                        ? "bg-primary text-primary-foreground ring-primary"
+                        : "bg-secondary text-secondary-foreground ring-border hover:bg-secondary/80"
+                    )}
+                    disabled={savingPreferences}
+                    key={category.name}
+                    onClick={() => togglePreference(category.name)}
+                    type="button"
+                  >
+                    {selected && <Check className="h-3.5 w-3.5" />}
+                    {category.name}
+                  </button>
+                )
+              })}
+            </div>
+          </motion.div>
+        )}
 
         <motion.div
           animate={{ opacity: 1, y: 0 }}

--- a/Frontend/hooks/use-polls.ts
+++ b/Frontend/hooks/use-polls.ts
@@ -30,7 +30,7 @@ export function usePolls(category?: string): UsePollsResult {
     setPolls([])
     setHasMore(true)
 
-    pollsApi.getTrending(PAGE_SIZE, category)
+    pollsApi.getPersonalized(PAGE_SIZE, category)
       .then((data) => {
         if (cancelled) return
         // US-19: filter out polls the user has already voted on

--- a/Frontend/lib/api.ts
+++ b/Frontend/lib/api.ts
@@ -137,6 +137,13 @@ export const pollsApi = {
     return request<ApiPoll[]>(`/api/polls/trending?${query.toString()}`)
   },
 
+  /** Fetch personalized polls. Anonymous users receive the default trending feed. */
+  getPersonalized: (count = 20, category?: string) => {
+    const query = new URLSearchParams({ count: String(count) })
+    if (category) query.set("category", category)
+    return request<ApiPoll[]>(`/api/polls/personalized?${query.toString()}`)
+  },
+
   /** Fetch all polls. Includes hasVoted when authenticated. */
   getAll: (category?: string) => {
     const query = categoryQuery(category)
@@ -243,6 +250,12 @@ export interface ApiVoteHistoryItem {
   votedAt: string
 }
 
+export interface ApiCategoryPreference {
+  category: string
+  isExplicit: boolean
+  voteCount: number
+}
+
 export const usersApi = {
   /** Leaderboard — top users by XP. */
   getLeaderboard: (count = 20) =>
@@ -251,6 +264,18 @@ export const usersApi = {
   /** Vote history for the current authenticated user. */
   getMyVotes: (count = 10) =>
     request<ApiVoteHistoryItem[]>(`/api/users/me/votes?count=${count}`),
+
+  getCategoryPreferences: () =>
+    request<ApiCategoryPreference[]>("/api/users/me/preferences/categories"),
+
+  updateCategoryPreferences: (categories: string[]) =>
+    request<ApiCategoryPreference[]>("/api/users/me/preferences/categories", {
+      method: "PUT",
+      body: JSON.stringify({ categories }),
+    }),
+
+  resetCategoryPreferences: () =>
+    request<void>("/api/users/me/preferences/categories", { method: "DELETE" }),
 }
 
 // ── Auth endpoints ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add user category preference storage and authenticated get/update/reset endpoints
- add a personalized poll feed endpoint that ranks published polls by explicit preferences, non-sensitive voting activity, trending status, and recency
- keep anonymous users on the existing default trending behavior
- switch the swipe feed to use the personalized endpoint
- add signed-in feed preference chips on the home page, excluding Health from preference ranking signals

## Verification
- `dotnet build` (passes; existing nullable warning remains in `Backend/BackendAPI/Repository/AuthRepository.cs`)
- `./node_modules/.bin/tsc --noEmit`
- `npm run build`
- `git diff --check`
- `npm run lint` is blocked because `eslint` is not installed in the frontend package

Closes #56