### PR TITLE
Add shareable poll result cards

### DIFF
--- a/Frontend/app/polls/[id]/page.tsx
+++ b/Frontend/app/polls/[id]/page.tsx
@@ -3,6 +3,7 @@ import { AppShell } from "@/components/app-shell"
 import { PollDetailCard } from "@/components/poll-detail/poll-detail-card"
 import { API_BASE_URL } from "@/lib/config"
 import type { ApiPoll } from "@/lib/api"
+import { appBaseUrl, isPollPubliclyShareable, pollShareUrl } from "@/lib/share"
 
 interface PollDetailPageProps {
   params: Promise<{ id: string }>
@@ -34,21 +35,27 @@ export async function generateMetadata({
   }
 
   const description = `${poll.totalVotes} votes - ${poll.category}`
+  const shareable = isPollPubliclyShareable(poll.category)
+  const url = pollShareUrl(poll.id)
 
   return {
     title: `${poll.question} | Pollify`,
-    description,
+    description: shareable ? description : "This Pollify poll is private.",
+    metadataBase: appBaseUrl() ? new URL(appBaseUrl()) : undefined,
+    alternates: shareable ? { canonical: url } : undefined,
+    robots: shareable ? undefined : { index: false, follow: false },
     openGraph: {
-      title: poll.question,
-      description,
-      images: poll.thumbnailUrl ? [{ url: poll.thumbnailUrl }] : undefined,
+      title: shareable ? poll.question : "Pollify",
+      description: shareable ? description : "This poll is not publicly shareable.",
+      images: shareable && poll.thumbnailUrl ? [{ url: poll.thumbnailUrl }] : undefined,
       type: "article",
+      url: shareable ? url : undefined,
     },
     twitter: {
-      card: poll.thumbnailUrl ? "summary_large_image" : "summary",
-      title: poll.question,
-      description,
-      images: poll.thumbnailUrl ? [poll.thumbnailUrl] : undefined,
+      card: shareable && poll.thumbnailUrl ? "summary_large_image" : "summary",
+      title: shareable ? poll.question : "Pollify",
+      description: shareable ? description : "This poll is not publicly shareable.",
+      images: shareable && poll.thumbnailUrl ? [poll.thumbnailUrl] : undefined,
     },
   }
 }

--- a/Frontend/components/poll-detail/poll-detail-card.tsx
+++ b/Frontend/components/poll-detail/poll-detail-card.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useCallback, useEffect, useMemo, useState } from "react"
-import { useRouter } from "next/navigation"
+import { useRouter, useSearchParams } from "next/navigation"
 import {
   AlertCircle,
   ArrowLeft,
@@ -22,6 +22,7 @@ import { Button } from "@/components/ui/button"
 import { useAuth } from "@/contexts/auth-context"
 import { pollsApi, votesApi, type ApiPoll, type ApiPollOption } from "@/lib/api"
 import { SOURCE_COLORS, SOURCE_LABELS, type IngestionSource } from "@/lib/poll-data"
+import { pollShareText, resultShareText } from "@/lib/share"
 import { cn } from "@/lib/utils"
 
 interface PollDetailCardProps {
@@ -91,6 +92,7 @@ function ResultBar({
 
 export function PollDetailCard({ pollId }: PollDetailCardProps) {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const { isAuthenticated, isLoading: authLoading } = useAuth()
   const [poll, setPoll] = useState<ApiPoll | null>(null)
   const [loading, setLoading] = useState(true)
@@ -220,7 +222,11 @@ export function PollDetailCard({ pollId }: PollDetailCardProps) {
   }
 
   const style = sourceStyle(poll.sourceType)
-  const showResults = poll.hasVoted || expired
+  const resultView = searchParams.get("view") === "results"
+  const showResults = poll.hasVoted || expired || resultView
+  const selectedOption = poll.options.find((option) => option.id === poll.userVotedOptionId)
+  const leadingOption = [...poll.options].sort((a, b) => (b.votePercentage ?? 0) - (a.votePercentage ?? 0))[0]
+  const resultOption = selectedOption ?? leadingOption
 
   return (
     <div className="mx-auto w-full max-w-3xl px-4 py-6">
@@ -268,8 +274,10 @@ export function PollDetailCard({ pollId }: PollDetailCardProps) {
             </div>
 
             <ShareButton
+              category={poll.category}
               className="bg-background/85 shadow-lg backdrop-blur-sm hover:bg-background"
               pollId={poll.id}
+              text={pollShareText(poll)}
               title={poll.question}
             />
           </div>
@@ -346,8 +354,18 @@ export function PollDetailCard({ pollId }: PollDetailCardProps) {
                 />
               ))}
               <p className="text-center text-sm text-muted-foreground">
-                {poll.hasVoted ? "You already voted" : "This poll has ended"}
+                {poll.hasVoted ? "You already voted" : expired ? "This poll has ended" : "Results preview"}
               </p>
+              <div className="flex justify-center">
+                <ShareButton
+                  category={poll.category}
+                  path={`/polls/${poll.id}?view=results`}
+                  pollId={poll.id}
+                  text={resultShareText(poll, resultOption)}
+                  title={`Poll result: ${poll.question}`}
+                  variant="outline"
+                />
+              </div>
             </div>
           ) : (
             <div className="grid gap-3 sm:grid-cols-2">

--- a/Frontend/components/poll-feed/poll-card.tsx
+++ b/Frontend/components/poll-feed/poll-card.tsx
@@ -19,6 +19,7 @@ import { cn } from "@/lib/utils"
 import { CategoryBadge } from "@/components/category-badge"
 import { ShareButton } from "@/components/share-button"
 import { Poll, SOURCE_COLORS, SOURCE_LABELS } from "@/lib/poll-data"
+import { pollShareText, resultShareText } from "@/lib/share"
 import {
   Tooltip,
   TooltipContent,
@@ -152,6 +153,9 @@ export function PollCard({ poll, onVote, isActive }: PollCardProps) {
   const yesOption       = poll.options?.[0]
   const noOption        = poll.options?.[poll.options.length - 1]
   const resultColors    = ["emerald", "red", "blue", "amber"] as const
+  const userResultOption = pollOptions.find((option) => option.id === poll.userVotedOptionId)
+  const leadingOption = [...pollOptions].sort((a, b) => (b.votePercentage ?? 0) - (a.votePercentage ?? 0))[0]
+  const resultOption = userResultOption ?? leadingOption
 
   function handleDragEnd(_: unknown, info: PanInfo) {
     if (hasVoted || !isBinaryPoll) return
@@ -276,8 +280,10 @@ export function PollCard({ poll, onVote, isActive }: PollCardProps) {
 
             <div className="flex flex-col items-end gap-2">
               <ShareButton
+                category={poll.category}
                 className="bg-background/85 shadow-lg backdrop-blur-sm hover:bg-background"
                 pollId={poll.id}
+                text={pollShareText(poll)}
                 title={poll.question}
               />
 
@@ -371,6 +377,16 @@ export function PollCard({ poll, onVote, isActive }: PollCardProps) {
                 <p className="text-center text-xs text-muted-foreground pt-1">
                   You already voted
                 </p>
+                <div className="flex justify-center">
+                  <ShareButton
+                    category={poll.category}
+                    path={`/polls/${poll.id}?view=results`}
+                    pollId={poll.id}
+                    text={resultShareText(poll, resultOption)}
+                    title={`Poll result: ${poll.question}`}
+                    variant="outline"
+                  />
+                </div>
               </motion.div>
             ) : !isBinaryPoll ? (
               <div className="grid gap-2">

--- a/Frontend/components/share-button.tsx
+++ b/Frontend/components/share-button.tsx
@@ -5,23 +5,17 @@ import type { MouseEvent } from "react"
 import { Button } from "@/components/ui/button"
 import { toast } from "@/hooks/use-toast"
 import { cn } from "@/lib/utils"
+import { appBaseUrl, isPollPubliclyShareable } from "@/lib/share"
 
 interface ShareButtonProps {
   pollId: number | string
   title: string
   className?: string
+  category?: string | null
+  disabledReason?: string
+  path?: string
+  text?: string
   variant?: "default" | "secondary" | "ghost" | "outline"
-}
-
-function appBaseUrl() {
-  const configured = process.env.NEXT_PUBLIC_BASE_URL
-  if (configured) return configured.replace(/\/+$/, "")
-
-  if (typeof window !== "undefined") {
-    return window.location.origin
-  }
-
-  return ""
 }
 
 function showShareToast(title: "Link copied!" | "Shared!") {
@@ -31,17 +25,21 @@ function showShareToast(title: "Link copied!" | "Shared!") {
 
 export function ShareButton({
   className,
+  category,
+  disabledReason,
+  path,
   pollId,
+  text,
   title,
   variant = "secondary",
 }: ShareButtonProps) {
   async function sharePoll(event: MouseEvent<HTMLButtonElement>) {
     event.stopPropagation()
 
-    const url = `${appBaseUrl()}/polls/${pollId}`
+    const url = `${appBaseUrl()}${path ?? `/polls/${pollId}`}`
     const shareData = {
       title,
-      text: title,
+      text: text ?? title,
       url,
     }
 
@@ -62,9 +60,13 @@ export function ShareButton({
     }
   }
 
+  if (!isPollPubliclyShareable(category)) {
+    return null
+  }
+
   return (
     <Button
-      aria-label="Share poll"
+      aria-label={disabledReason ?? "Share poll"}
       className={cn("gap-2", className)}
       onClick={sharePoll}
       onPointerDown={(event) => event.stopPropagation()}

--- a/Frontend/lib/share.ts
+++ b/Frontend/lib/share.ts
@@ -1,0 +1,45 @@
+type ShareablePoll = {
+  id: number | string
+  question: string
+  category?: string | null
+  totalVotes?: number
+}
+
+type ShareableOption = {
+  text: string
+  votePercentage?: number | null
+}
+
+export function appBaseUrl() {
+  const configured = process.env.NEXT_PUBLIC_BASE_URL
+  if (configured) return configured.replace(/\/+$/, "")
+
+  if (typeof window !== "undefined") {
+    return window.location.origin
+  }
+
+  return ""
+}
+
+export function isPollPubliclyShareable(category?: string | null) {
+  return !category?.trim().toLowerCase().includes("health")
+}
+
+export function pollShareUrl(pollId: number | string) {
+  return `${appBaseUrl()}/polls/${pollId}`
+}
+
+export function pollResultShareUrl(pollId: number | string) {
+  return `${pollShareUrl(pollId)}?view=results`
+}
+
+export function pollShareText(poll: ShareablePoll) {
+  return `${poll.question}${poll.totalVotes != null ? ` (${poll.totalVotes.toLocaleString()} votes)` : ""}`
+}
+
+export function resultShareText(poll: ShareablePoll, option?: ShareableOption | null) {
+  if (!option) return pollShareText(poll)
+
+  const percentage = Math.round(option.votePercentage ?? 0)
+  return `${poll.question} Result: ${option.text} is at ${percentage}%`
+}


### PR DESCRIPTION
## Summary
- Add shared URL/text helpers for poll and result sharing
- Add poll and result share actions on feed/detail cards, including post-vote result shares
- Open shared result links directly in the results view via `?view=results`
- Add poll page canonical, Open Graph, and Twitter metadata for public polls
- Suppress sharing/preview metadata for Health-category polls by default

## Verification
- `dotnet build`
- `./node_modules/.bin/tsc --noEmit` from `Frontend`
- `git diff --check`
- `npm run build`
- `npm run lint` could not complete because `eslint` is not installed in `Frontend`

Closes #57