### PR TITLE
Add retention notification triggers

### DIFF
--- a/Backend/BackendAPI/Controllers/NotificationsController.cs
+++ b/Backend/BackendAPI/Controllers/NotificationsController.cs
@@ -1,4 +1,5 @@
 using BackendAPI.Interfaces;
+using BackendAPI.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Security.Claims;
@@ -59,6 +60,31 @@ namespace BackendAPI.Controllers
             return updated
                 ? Ok(new { success = true })
                 : NotFound(new { message = $"Notification {id} not found." });
+        }
+
+        // GET /api/notifications/preferences
+        [HttpGet("preferences")]
+        public async Task<IActionResult> GetPreferences()
+        {
+            var userId = CurrentUserId();
+            if (userId == null) return Unauthorized(new { message = "Invalid token." });
+
+            var preferences = await _notificationsRepo.GetPreferencesAsync(userId.Value);
+            return Ok(preferences);
+        }
+
+        // PUT /api/notifications/preferences
+        [HttpPut("preferences")]
+        public async Task<IActionResult> UpdatePreferences(
+            [FromBody] UpdateNotificationPreferencesRequest request)
+        {
+            var userId = CurrentUserId();
+            if (userId == null) return Unauthorized(new { message = "Invalid token." });
+
+            var preferences = await _notificationsRepo.ReplacePreferencesAsync(
+                userId.Value,
+                request.DisabledTypes);
+            return Ok(preferences);
         }
     }
 }

--- a/Backend/BackendAPI/Interfaces/INotificationsRepository.cs
+++ b/Backend/BackendAPI/Interfaces/INotificationsRepository.cs
@@ -9,5 +9,13 @@ namespace BackendAPI.Interfaces
         Task<int> GetUnreadCountAsync(long userId);
         Task MarkAllReadAsync(long userId);
         Task<bool> MarkReadAsync(long userId, long notificationId);
+        Task<IEnumerable<NotificationPreference>> GetPreferencesAsync(long userId);
+        Task<IEnumerable<NotificationPreference>> ReplacePreferencesAsync(
+            long userId,
+            IEnumerable<NotificationType> disabledTypes);
+        Task<int> CreateDailyChallengeNotificationsAsync(DateTime utcNow);
+        Task<int> CreateStreakReminderNotificationsAsync(DateTime utcNow);
+        Task<int> CreateTrendingPollNotificationsAsync(DateTime utcNow);
+        Task<int> CreateExpiringPollNotificationsAsync(DateTime utcNow);
     }
 }

--- a/Backend/BackendAPI/Jobs/RetentionNotificationJob.cs
+++ b/Backend/BackendAPI/Jobs/RetentionNotificationJob.cs
@@ -1,0 +1,39 @@
+using BackendAPI.Interfaces;
+
+namespace BackendAPI.Jobs
+{
+    public class RetentionNotificationJob
+    {
+        private readonly IChallengesRepository _challengesRepo;
+        private readonly INotificationsRepository _notificationsRepo;
+        private readonly ILogger<RetentionNotificationJob> _logger;
+
+        public RetentionNotificationJob(
+            IChallengesRepository challengesRepo,
+            INotificationsRepository notificationsRepo,
+            ILogger<RetentionNotificationJob> logger)
+        {
+            _challengesRepo = challengesRepo;
+            _notificationsRepo = notificationsRepo;
+            _logger = logger;
+        }
+
+        public async Task RunAsync()
+        {
+            var utcNow = DateTime.UtcNow;
+            await _challengesRepo.EnsureDailyChallengeAsync(utcNow);
+
+            var challengeCount = await _notificationsRepo.CreateDailyChallengeNotificationsAsync(utcNow);
+            var streakCount = await _notificationsRepo.CreateStreakReminderNotificationsAsync(utcNow);
+            var trendingCount = await _notificationsRepo.CreateTrendingPollNotificationsAsync(utcNow);
+            var expiringCount = await _notificationsRepo.CreateExpiringPollNotificationsAsync(utcNow);
+
+            _logger.LogInformation(
+                "[RetentionNotificationJob] Created notifications. challenge={ChallengeCount}, streak={StreakCount}, trending={TrendingCount}, expiring={ExpiringCount}",
+                challengeCount,
+                streakCount,
+                trendingCount,
+                expiringCount);
+        }
+    }
+}

--- a/Backend/BackendAPI/Migrations/US58_Notification_Retention.sql
+++ b/Backend/BackendAPI/Migrations/US58_Notification_Retention.sql
@@ -1,0 +1,38 @@
+IF COL_LENGTH('dbo.Notifications', 'DedupKey') IS NULL
+BEGIN
+    ALTER TABLE dbo.Notifications ADD DedupKey NVARCHAR(160) NULL;
+END;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE name = 'IX_Notifications_User_DedupKey'
+      AND object_id = OBJECT_ID('dbo.Notifications')
+)
+BEGIN
+    CREATE UNIQUE INDEX IX_Notifications_User_DedupKey
+    ON dbo.Notifications (UserId, DedupKey)
+    WHERE DedupKey IS NOT NULL;
+END;
+
+IF OBJECT_ID('dbo.NotificationPreferences', 'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.NotificationPreferences (
+        Id BIGINT IDENTITY(1,1) PRIMARY KEY,
+        UserId BIGINT NOT NULL,
+        Type NVARCHAR(40) NOT NULL,
+        IsEnabled BIT NOT NULL CONSTRAINT DF_NotificationPreferences_IsEnabled DEFAULT 1,
+        UpdatedAt DATETIME2 NOT NULL CONSTRAINT DF_NotificationPreferences_UpdatedAt DEFAULT GETUTCDATE(),
+        CONSTRAINT FK_NotificationPreferences_Users FOREIGN KEY (UserId) REFERENCES dbo.Users(Id),
+        CONSTRAINT UQ_NotificationPreferences_UserType UNIQUE (UserId, Type)
+    );
+END;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE name = 'IX_NotificationPreferences_User'
+      AND object_id = OBJECT_ID('dbo.NotificationPreferences')
+)
+BEGIN
+    CREATE INDEX IX_NotificationPreferences_User
+    ON dbo.NotificationPreferences (UserId, Type, IsEnabled);
+END;

--- a/Backend/BackendAPI/Models/Notification.cs
+++ b/Backend/BackendAPI/Models/Notification.cs
@@ -5,7 +5,10 @@ namespace BackendAPI.Models
         VoteMilestone,
         LevelUp,
         PollTrending,
-        DailyReminder
+        DailyReminder,
+        ChallengeAvailable,
+        StreakReminder,
+        PollExpiring
     }
 
     public class Notification
@@ -16,6 +19,7 @@ namespace BackendAPI.Models
         public string Title { get; set; } = string.Empty;
         public string Body { get; set; } = string.Empty;
         public long? PollId { get; set; }
+        public string? DedupKey { get; set; }
         public bool IsRead { get; set; }
         public DateTime CreatedAt { get; set; }
     }
@@ -27,5 +31,17 @@ namespace BackendAPI.Models
         public string Title { get; set; } = string.Empty;
         public string Body { get; set; } = string.Empty;
         public long? PollId { get; set; }
+        public string? DedupKey { get; set; }
+    }
+
+    public class NotificationPreference
+    {
+        public NotificationType Type { get; set; }
+        public bool IsEnabled { get; set; } = true;
+    }
+
+    public class UpdateNotificationPreferencesRequest
+    {
+        public List<NotificationType> DisabledTypes { get; set; } = new();
     }
 }

--- a/Backend/BackendAPI/Program.cs
+++ b/Backend/BackendAPI/Program.cs
@@ -79,6 +79,7 @@ builder.Services.AddScoped<IPollGenerationService, PollGenerationService>();
 // ── Hangfire Jobs — must be registered in DI so Hangfire can resolve them ─
 builder.Services.AddScoped<IngestionJob>();
 builder.Services.AddScoped<PollGenerationJob>();
+builder.Services.AddScoped<RetentionNotificationJob>();
 
 // ── Hangfire Dashboard Auth (US-11) ───────────────────────────────────────
 builder.Services.AddSingleton<HangfireDashboardAuthFilter>();
@@ -156,6 +157,11 @@ using (var scope = app.Services.CreateScope())
         "generate-polls-from-topics",
         job => job.RunAsync(),
         "5/35 * * * *");
+
+    recurringJobs.AddOrUpdate<RetentionNotificationJob>(
+        "create-retention-notifications",
+        job => job.RunAsync(),
+        "0 * * * *");
 }
 
 app.Run();

--- a/Backend/BackendAPI/Repository/NotificationsRepository.cs
+++ b/Backend/BackendAPI/Repository/NotificationsRepository.cs
@@ -17,19 +17,36 @@ namespace BackendAPI.Repository
         public async Task<long> CreateAsync(CreateNotificationRequest request)
         {
             using var conn = _context.CreateConnection();
-            return await conn.ExecuteScalarAsync<long>(
-                @"INSERT INTO Notifications (UserId, Type, Title, Body, PollId, IsRead, CreatedAt)
-                  VALUES (@UserId, @Type, @Title, @Body, @PollId, 0, GETUTCDATE());
-                  SELECT CAST(SCOPE_IDENTITY() AS BIGINT);",
+            return await conn.ExecuteScalarAsync<long?>(
+                @"IF NOT EXISTS (
+                      SELECT 1 FROM NotificationPreferences
+                      WHERE UserId = @UserId AND Type = @Type AND IsEnabled = 0
+                  )
+                  AND (
+                      @DedupKey IS NULL OR NOT EXISTS (
+                          SELECT 1 FROM Notifications
+                          WHERE UserId = @UserId AND DedupKey = @DedupKey
+                      )
+                  )
+                  BEGIN
+                      INSERT INTO Notifications (UserId, Type, Title, Body, PollId, DedupKey, IsRead, CreatedAt)
+                      VALUES (@UserId, @Type, @Title, @Body, @PollId, @DedupKey, 0, GETUTCDATE());
+                      SELECT CAST(SCOPE_IDENTITY() AS BIGINT);
+                  END
+                  ELSE
+                  BEGIN
+                      SELECT CAST(0 AS BIGINT);
+                  END",
                 new
                 {
                     request.UserId,
                     Type = request.Type.ToString(),
                     request.Title,
                     request.Body,
-                    request.PollId
+                    request.PollId,
+                    request.DedupKey
                 }
-            );
+            ) ?? 0;
         }
 
         public async Task<IEnumerable<Notification>> GetForUserAsync(long userId, int count = 30)
@@ -72,6 +89,181 @@ namespace BackendAPI.Repository
                 new { NotificationId = notificationId, UserId = userId }
             );
             return rows > 0;
+        }
+
+        public async Task<IEnumerable<NotificationPreference>> GetPreferencesAsync(long userId)
+        {
+            return await QueryPreferencesAsync(userId);
+        }
+
+        public async Task<IEnumerable<NotificationPreference>> ReplacePreferencesAsync(
+            long userId,
+            IEnumerable<NotificationType> disabledTypes)
+        {
+            var disabled = disabledTypes.Distinct().Select(type => type.ToString()).ToList();
+
+            using var conn = _context.CreateConnection();
+            conn.Open();
+            using var transaction = conn.BeginTransaction();
+
+            try
+            {
+                await conn.ExecuteAsync(
+                    "DELETE FROM NotificationPreferences WHERE UserId = @UserId",
+                    new { UserId = userId },
+                    transaction);
+
+                foreach (var type in Enum.GetValues<NotificationType>())
+                {
+                    await conn.ExecuteAsync(
+                        @"INSERT INTO NotificationPreferences (UserId, Type, IsEnabled, UpdatedAt)
+                          VALUES (@UserId, @Type, @IsEnabled, GETUTCDATE())",
+                        new
+                        {
+                            UserId = userId,
+                            Type = type.ToString(),
+                            IsEnabled = !disabled.Contains(type.ToString())
+                        },
+                        transaction);
+                }
+
+                transaction.Commit();
+            }
+            catch
+            {
+                transaction.Rollback();
+                throw;
+            }
+
+            return await QueryPreferencesAsync(userId);
+        }
+
+        public async Task<int> CreateDailyChallengeNotificationsAsync(DateTime utcNow)
+        {
+            using var conn = _context.CreateConnection();
+            return await conn.ExecuteAsync(
+                RetentionInsertSql(
+                    NotificationType.ChallengeAvailable,
+                    @"SELECT u.Id AS UserId,
+                             NULL AS PollId,
+                             CONCAT('challenge:', c.Id, ':available:', CONVERT(char(8), @UtcNow, 112)) AS DedupKey,
+                             'Daily challenge is live' AS Title,
+                             CONCAT(c.Title, ' is available now. Vote ', c.RequiredVotes, ' times before it ends for +', c.RewardXp, ' XP.') AS Body
+                      FROM Users u
+                      JOIN Challenges c
+                        ON c.IsActive = 1
+                       AND c.StartAt <= @UtcNow
+                       AND c.EndAt > @UtcNow
+                      LEFT JOIN UserChallengeProgress progress
+                        ON progress.UserId = u.Id AND progress.ChallengeId = c.Id
+                      WHERE COALESCE(progress.IsCompleted, 0) = 0"),
+                new { UtcNow = utcNow, Type = NotificationType.ChallengeAvailable.ToString() });
+        }
+
+        public async Task<int> CreateStreakReminderNotificationsAsync(DateTime utcNow)
+        {
+            using var conn = _context.CreateConnection();
+            return await conn.ExecuteAsync(
+                RetentionInsertSql(
+                    NotificationType.StreakReminder,
+                    @"SELECT u.Id AS UserId,
+                             NULL AS PollId,
+                             CONCAT('streak:', u.Id, ':', CONVERT(char(8), @UtcNow, 112)) AS DedupKey,
+                             'Keep your streak alive' AS Title,
+                             CONCAT('Your ', u.Streak, '-day streak is waiting. Vote once today to keep it going.') AS Body
+                      FROM Users u
+                      WHERE u.Streak > 0
+                        AND CONVERT(date, u.LastVoteDate) = DATEADD(day, -1, CONVERT(date, @UtcNow))"),
+                new { UtcNow = utcNow, Type = NotificationType.StreakReminder.ToString() });
+        }
+
+        public async Task<int> CreateTrendingPollNotificationsAsync(DateTime utcNow)
+        {
+            using var conn = _context.CreateConnection();
+            return await conn.ExecuteAsync(
+                RetentionInsertSql(
+                    NotificationType.PollTrending,
+                    @"SELECT u.Id AS UserId,
+                             p.Id AS PollId,
+                             CONCAT('trending:', p.Id, ':', CONVERT(char(8), @UtcNow, 112)) AS DedupKey,
+                             'A poll is trending' AS Title,
+                             CONCAT('People are voting on: ', p.Question) AS Body
+                      FROM Users u
+                      CROSS JOIN (
+                          SELECT TOP (3) Id, Question
+                          FROM Polls
+                          WHERE IsActive = 1
+                            AND ModerationStatus = 'Published'
+                            AND Category <> 'Health'
+                            AND ExpiresAt > @UtcNow
+                            AND (IsTrending = 1 OR TotalVotes >= 10)
+                          ORDER BY IsTrending DESC, TotalVotes DESC, CreatedAt DESC
+                      ) p
+                      WHERE NOT EXISTS (
+                          SELECT 1 FROM Votes v WHERE v.UserId = u.Id AND v.PollId = p.Id
+                      )"),
+                new { UtcNow = utcNow, Type = NotificationType.PollTrending.ToString() });
+        }
+
+        public async Task<int> CreateExpiringPollNotificationsAsync(DateTime utcNow)
+        {
+            using var conn = _context.CreateConnection();
+            return await conn.ExecuteAsync(
+                RetentionInsertSql(
+                    NotificationType.PollExpiring,
+                    @"SELECT u.Id AS UserId,
+                             p.Id AS PollId,
+                             CONCAT('expiring:', p.Id, ':', CONVERT(char(8), @UtcNow, 112)) AS DedupKey,
+                             'Poll closing soon' AS Title,
+                             CONCAT('Last chance to vote: ', p.Question) AS Body
+                      FROM Users u
+                      CROSS JOIN (
+                          SELECT TOP (5) Id, Question
+                          FROM Polls
+                          WHERE IsActive = 1
+                            AND ModerationStatus = 'Published'
+                            AND Category <> 'Health'
+                            AND ExpiresAt > @UtcNow
+                            AND ExpiresAt <= DATEADD(hour, 6, @UtcNow)
+                          ORDER BY ExpiresAt ASC, TotalVotes DESC
+                      ) p
+                      WHERE NOT EXISTS (
+                          SELECT 1 FROM Votes v WHERE v.UserId = u.Id AND v.PollId = p.Id
+                      )"),
+                new { UtcNow = utcNow, Type = NotificationType.PollExpiring.ToString() });
+        }
+
+        private async Task<IEnumerable<NotificationPreference>> QueryPreferencesAsync(long userId)
+        {
+            using var conn = _context.CreateConnection();
+            var rows = (await conn.QueryAsync<NotificationPreference>(
+                @"SELECT Type, IsEnabled
+                  FROM NotificationPreferences
+                  WHERE UserId = @UserId",
+                new { UserId = userId })).ToDictionary(row => row.Type);
+
+            return Enum.GetValues<NotificationType>()
+                .Select(type => rows.TryGetValue(type, out var existing)
+                    ? existing
+                    : new NotificationPreference { Type = type, IsEnabled = true });
+        }
+
+        private static string RetentionInsertSql(NotificationType type, string sourceSql)
+        {
+            return $@"WITH Candidates AS (
+                        {sourceSql}
+                      )
+                      INSERT INTO Notifications (UserId, Type, Title, Body, PollId, DedupKey, IsRead, CreatedAt)
+                      SELECT c.UserId, @Type, c.Title, c.Body, c.PollId, c.DedupKey, 0, GETUTCDATE()
+                      FROM Candidates c
+                      WHERE NOT EXISTS (
+                          SELECT 1 FROM NotificationPreferences pref
+                          WHERE pref.UserId = c.UserId AND pref.Type = @Type AND pref.IsEnabled = 0
+                      )
+                        AND NOT EXISTS (
+                          SELECT 1 FROM Notifications existing
+                          WHERE existing.UserId = c.UserId AND existing.DedupKey = c.DedupKey
+                      );";
         }
     }
 }

--- a/Frontend/app/notifications/page.tsx
+++ b/Frontend/app/notifications/page.tsx
@@ -5,8 +5,9 @@ import { useRouter } from "next/navigation"
 import { Bell, CheckCheck, Loader2, RefreshCw, Sparkles, TrendingUp, Trophy } from "lucide-react"
 import { AppShell } from "@/components/app-shell"
 import { Button } from "@/components/ui/button"
+import { Switch } from "@/components/ui/switch"
 import { useAuth } from "@/contexts/auth-context"
-import { notificationsApi, type ApiNotification } from "@/lib/api"
+import { notificationsApi, type ApiNotification, type ApiNotificationPreference } from "@/lib/api"
 import { cn } from "@/lib/utils"
 
 function relativeTime(iso: string) {
@@ -24,9 +25,25 @@ function notificationIcon(type: ApiNotification["type"]) {
       return TrendingUp
     case "LevelUp":
       return Trophy
+    case "PollTrending":
+      return TrendingUp
+    case "ChallengeAvailable":
+    case "StreakReminder":
+    case "PollExpiring":
+      return Bell
     default:
       return Sparkles
   }
+}
+
+const preferenceLabels: Record<ApiNotification["type"], string> = {
+  VoteMilestone: "Vote milestones",
+  LevelUp: "Level ups",
+  PollTrending: "Trending polls",
+  DailyReminder: "Daily reminders",
+  ChallengeAvailable: "Daily challenges",
+  StreakReminder: "Streak risk",
+  PollExpiring: "Expiring polls",
 }
 
 export default function NotificationsPage() {
@@ -34,6 +51,8 @@ export default function NotificationsPage() {
   const { isAuthenticated, isLoading: authLoading } = useAuth()
   const [notifications, setNotifications] = useState<ApiNotification[]>([])
   const [unreadCount, setUnreadCount] = useState(0)
+  const [preferences, setPreferences] = useState<ApiNotificationPreference[]>([])
+  const [savingPreference, setSavingPreference] = useState<ApiNotification["type"] | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -43,9 +62,13 @@ export default function NotificationsPage() {
     setLoading(true)
     setError(null)
     try {
-      const response = await notificationsApi.getAll()
+      const [response, loadedPreferences] = await Promise.all([
+        notificationsApi.getAll(),
+        notificationsApi.getPreferences(),
+      ])
       setNotifications(response.notifications)
       setUnreadCount(response.unreadCount)
+      setPreferences(loadedPreferences)
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not load notifications")
     } finally {
@@ -78,6 +101,26 @@ export default function NotificationsPage() {
     setNotifications((current) => current.map((item) => ({ ...item, isRead: true })))
     setUnreadCount(0)
     await notificationsApi.markAllRead().catch(() => loadNotifications())
+  }
+
+  async function togglePreference(type: ApiNotification["type"], isEnabled: boolean) {
+    setSavingPreference(type)
+    const next = preferences.map((preference) =>
+      preference.type === type ? { ...preference, isEnabled } : preference
+    )
+    setPreferences(next)
+
+    try {
+      const disabledTypes = next
+        .filter((preference) => !preference.isEnabled)
+        .map((preference) => preference.type)
+      const updated = await notificationsApi.updatePreferences(disabledTypes)
+      setPreferences(updated)
+    } catch {
+      loadNotifications()
+    } finally {
+      setSavingPreference(null)
+    }
   }
 
   return (
@@ -148,6 +191,34 @@ export default function NotificationsPage() {
               Start voting to earn XP!
             </p>
           </div>
+        )}
+
+        {!loading && !error && preferences.length > 0 && (
+          <section className="mb-6 rounded-2xl border border-border/60 bg-card p-4">
+            <div className="mb-3">
+              <h2 className="font-semibold text-foreground">Notification preferences</h2>
+              <p className="text-sm text-muted-foreground">
+                Control which retention reminders appear in your inbox.
+              </p>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {preferences.map((preference) => (
+                <label
+                  className="flex items-center justify-between gap-3 rounded-xl border border-border/50 px-3 py-2"
+                  key={preference.type}
+                >
+                  <span className="text-sm font-medium text-foreground">
+                    {preferenceLabels[preference.type]}
+                  </span>
+                  <Switch
+                    checked={preference.isEnabled}
+                    disabled={savingPreference === preference.type}
+                    onCheckedChange={(checked) => togglePreference(preference.type, checked)}
+                  />
+                </label>
+              ))}
+            </div>
+          </section>
         )}
 
         {!loading && !error && notifications.length > 0 && (

--- a/Frontend/lib/api.ts
+++ b/Frontend/lib/api.ts
@@ -84,10 +84,11 @@ export interface ApiChallenge {
 export interface ApiNotification {
   id: number
   userId: number
-  type: "VoteMilestone" | "LevelUp" | "PollTrending" | "DailyReminder"
+  type: "VoteMilestone" | "LevelUp" | "PollTrending" | "DailyReminder" | "ChallengeAvailable" | "StreakReminder" | "PollExpiring"
   title: string
   body: string
   pollId: number | null
+  dedupKey: string | null
   isRead: boolean
   createdAt: string
 }
@@ -95,6 +96,11 @@ export interface ApiNotification {
 export interface ApiNotificationsResponse {
   notifications: ApiNotification[]
   unreadCount: number
+}
+
+export interface ApiNotificationPreference {
+  type: ApiNotification["type"]
+  isEnabled: boolean
 }
 
 export interface CreatePollPayload {
@@ -238,6 +244,15 @@ export const notificationsApi = {
 
   markRead: (id: number) =>
     request<void>(`/api/notifications/${id}/read`, { method: "PATCH" }),
+
+  getPreferences: () =>
+    request<ApiNotificationPreference[]>("/api/notifications/preferences"),
+
+  updatePreferences: (disabledTypes: ApiNotification["type"][]) =>
+    request<ApiNotificationPreference[]>("/api/notifications/preferences", {
+      method: "PUT",
+      body: JSON.stringify({ disabledTypes }),
+    }),
 }
 
 // ── User endpoints ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add notification preference storage and APIs so users can disable notification types
- Add dedup keys for notification records to prevent repeated retention nudges
- Add a Hangfire retention notification job for daily challenges, streak reminders, trending polls, and expiring polls
- Add preference controls to the notifications page while keeping the existing read/unread flow

## Verification
- `dotnet build`
- `./node_modules/.bin/tsc --noEmit` from `Frontend`
- `git diff --check`
- `npm run build`
- `npm run lint` could not complete because `eslint` is not installed in `Frontend`

Closes #58