### PR TITLE
Add business campaign analytics dashboard

### DIFF
--- a/Backend/BackendAPI/Controllers/BusinessController.cs
+++ b/Backend/BackendAPI/Controllers/BusinessController.cs
@@ -2,6 +2,7 @@ using BackendAPI.Interfaces;
 using BackendAPI.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System.Text;
 using System.Security.Claims;
 
 namespace BackendAPI.Controllers
@@ -59,6 +60,59 @@ namespace BackendAPI.Controllers
             return Ok(campaigns);
         }
 
+        [HttpGet("campaigns/{campaignId}/analytics")]
+        public async Task<IActionResult> GetCampaignAnalytics(long campaignId)
+        {
+            var userId = CurrentUserId();
+            if (userId == null) return Unauthorized(new { message = "Invalid token." });
+
+            var analytics = await _businessRepo.GetCampaignAnalyticsAsync(userId.Value, campaignId);
+            return analytics == null
+                ? NotFound(new { message = $"Campaign {campaignId} not found." })
+                : Ok(analytics);
+        }
+
+        [HttpGet("campaigns/{campaignId}/export.csv")]
+        public async Task<IActionResult> ExportCampaignAnalytics(long campaignId)
+        {
+            var userId = CurrentUserId();
+            if (userId == null) return Unauthorized(new { message = "Invalid token." });
+
+            var analytics = await _businessRepo.GetCampaignAnalyticsAsync(userId.Value, campaignId);
+            if (analytics == null) return NotFound(new { message = $"Campaign {campaignId} not found." });
+
+            var csv = new StringBuilder();
+            csv.AppendLine("Campaign,PollId,Question,Status,Impressions,Votes,Completions,CompletionRate,Option,OptionVotes,OptionPercentage");
+
+            foreach (var poll in analytics.Polls)
+            {
+                var options = analytics.OptionBreakdown
+                    .Where(option => option.PollId == poll.PollId)
+                    .DefaultIfEmpty(new CampaignOptionBreakdown());
+
+                foreach (var option in options)
+                {
+                    csv.AppendLine(string.Join(",",
+                        Csv(analytics.Campaign.Name),
+                        poll.PollId,
+                        Csv(poll.Question),
+                        Csv(poll.ModerationStatus),
+                        poll.Impressions,
+                        poll.Votes,
+                        poll.Completions,
+                        poll.CompletionRate.ToString("0.##"),
+                        Csv(option.OptionText),
+                        option.VoteCount,
+                        option.VotePercentage.ToString("0.##")));
+                }
+            }
+
+            return File(
+                Encoding.UTF8.GetBytes(csv.ToString()),
+                "text/csv",
+                $"campaign-{campaignId}-analytics.csv");
+        }
+
         [HttpPost("accounts/{businessId}/campaigns")]
         public async Task<IActionResult> CreateCampaign(
             long businessId,
@@ -94,6 +148,12 @@ namespace BackendAPI.Controllers
 
             var poll = await _pollsRepo.GetByIdAsync(pollId.Value, userId.Value);
             return CreatedAtAction("GetById", "Polls", new { id = pollId.Value }, poll);
+        }
+
+        private static string Csv(string? value)
+        {
+            var text = value ?? string.Empty;
+            return $"\"{text.Replace("\"", "\"\"")}\"";
         }
     }
 }

--- a/Backend/BackendAPI/Interfaces/IBusinessRepository.cs
+++ b/Backend/BackendAPI/Interfaces/IBusinessRepository.cs
@@ -8,6 +8,7 @@ namespace BackendAPI.Interfaces
         Task<IEnumerable<BusinessAccount>> GetBusinessesForUserAsync(long ownerUserId);
         Task<BusinessCampaign?> CreateCampaignAsync(long ownerUserId, long businessId, CreateBusinessCampaignRequest request);
         Task<IEnumerable<BusinessCampaign>> GetCampaignsForUserAsync(long ownerUserId);
+        Task<CampaignAnalytics?> GetCampaignAnalyticsAsync(long ownerUserId, long campaignId);
         Task<long?> CreateSponsoredPollAsync(long ownerUserId, CreateSponsoredPollRequest request);
         Task<bool> RecordImpressionAsync(long pollId);
         Task RecordVoteAsync(long pollId);

--- a/Backend/BackendAPI/Models/Business.cs
+++ b/Backend/BackendAPI/Models/Business.cs
@@ -59,11 +59,37 @@ namespace BackendAPI.Models
     {
         public long CampaignId { get; set; }
         public long PollId { get; set; }
+        public string Question { get; set; } = string.Empty;
+        public string ModerationStatus { get; set; } = string.Empty;
+        public DateTime CreatedAt { get; set; }
         public int Impressions { get; set; }
         public int Votes { get; set; }
         public int Completions { get; set; }
         public double CompletionRate { get; set; }
         public DateTime UpdatedAt { get; set; }
+    }
+
+    public class CampaignOptionBreakdown
+    {
+        public long PollId { get; set; }
+        public long OptionId { get; set; }
+        public string OptionText { get; set; } = string.Empty;
+        public int VoteCount { get; set; }
+        public double VotePercentage { get; set; }
+    }
+
+    public class CampaignDailyMetric
+    {
+        public DateTime Date { get; set; }
+        public int Votes { get; set; }
+    }
+
+    public class CampaignAnalytics
+    {
+        public BusinessCampaign Campaign { get; set; } = new();
+        public List<CampaignPollMetric> Polls { get; set; } = new();
+        public List<CampaignOptionBreakdown> OptionBreakdown { get; set; } = new();
+        public List<CampaignDailyMetric> DailyVotes { get; set; } = new();
     }
 
     public class CreateBusinessAccountRequest

--- a/Backend/BackendAPI/Repository/BusinessRepository.cs
+++ b/Backend/BackendAPI/Repository/BusinessRepository.cs
@@ -102,6 +102,83 @@ namespace BackendAPI.Repository
                 new { OwnerUserId = ownerUserId });
         }
 
+        public async Task<CampaignAnalytics?> GetCampaignAnalyticsAsync(long ownerUserId, long campaignId)
+        {
+            using var conn = _context.CreateConnection();
+
+            var campaign = await conn.QuerySingleOrDefaultAsync<BusinessCampaign>(
+                @"SELECT c.*,
+                         b.Name AS BusinessName,
+                         COALESCE(SUM(m.Impressions), 0) AS Impressions,
+                         COALESCE(SUM(m.Votes), 0) AS Votes,
+                         COALESCE(SUM(m.Completions), 0) AS Completions,
+                         CAST(CASE
+                            WHEN COALESCE(SUM(m.Impressions), 0) = 0 THEN 0
+                            ELSE COALESCE(SUM(m.Completions), 0) * 100.0 / COALESCE(SUM(m.Impressions), 0)
+                         END AS float) AS CompletionRate
+                  FROM BusinessCampaigns c
+                  JOIN BusinessAccounts b ON b.Id = c.BusinessId
+                  LEFT JOIN SponsoredPollMetrics m ON m.CampaignId = c.Id
+                  WHERE c.Id = @CampaignId AND b.OwnerUserId = @OwnerUserId
+                  GROUP BY c.Id, c.BusinessId, b.Name, c.Name, c.Objective, c.StartsAt, c.EndsAt, c.Status, c.CreatedAt",
+                new { CampaignId = campaignId, OwnerUserId = ownerUserId });
+
+            if (campaign == null) return null;
+
+            var polls = (await conn.QueryAsync<CampaignPollMetric>(
+                @"SELECT
+                      m.CampaignId,
+                      p.Id AS PollId,
+                      p.Question,
+                      p.ModerationStatus,
+                      p.CreatedAt,
+                      m.Impressions,
+                      m.Votes,
+                      m.Completions,
+                      CAST(CASE
+                          WHEN m.Impressions = 0 THEN 0
+                          ELSE m.Completions * 100.0 / m.Impressions
+                      END AS float) AS CompletionRate,
+                      m.UpdatedAt
+                  FROM SponsoredPollMetrics m
+                  JOIN Polls p ON p.Id = m.PollId
+                  WHERE m.CampaignId = @CampaignId
+                  ORDER BY p.CreatedAt DESC",
+                new { CampaignId = campaignId })).ToList();
+
+            var optionBreakdown = (await conn.QueryAsync<CampaignOptionBreakdown>(
+                @"SELECT
+                      p.Id AS PollId,
+                      o.Id AS OptionId,
+                      o.Text AS OptionText,
+                      o.VoteCount,
+                      o.VotePercentage
+                  FROM Polls p
+                  JOIN PollOptions o ON o.PollId = p.Id
+                  WHERE p.CampaignId = @CampaignId
+                  ORDER BY p.Id, o.VoteCount DESC, o.Id",
+                new { CampaignId = campaignId })).ToList();
+
+            var dailyVotes = (await conn.QueryAsync<CampaignDailyMetric>(
+                @"SELECT
+                      CAST(CONVERT(date, v.CreatedAt) AS datetime2) AS Date,
+                      COUNT(1) AS Votes
+                  FROM Votes v
+                  JOIN Polls p ON p.Id = v.PollId
+                  WHERE p.CampaignId = @CampaignId
+                  GROUP BY CONVERT(date, v.CreatedAt)
+                  ORDER BY Date ASC",
+                new { CampaignId = campaignId })).ToList();
+
+            return new CampaignAnalytics
+            {
+                Campaign = campaign,
+                Polls = polls,
+                OptionBreakdown = optionBreakdown,
+                DailyVotes = dailyVotes
+            };
+        }
+
         public async Task<long?> CreateSponsoredPollAsync(long ownerUserId, CreateSponsoredPollRequest request)
         {
             using var conn = _context.CreateConnection();

--- a/Frontend/app/business/page.tsx
+++ b/Frontend/app/business/page.tsx
@@ -2,25 +2,41 @@
 
 import { FormEvent, useCallback, useEffect, useMemo, useState } from "react"
 import { useRouter } from "next/navigation"
-import { BriefcaseBusiness, Loader2, Megaphone, Plus, RefreshCw } from "lucide-react"
+import {
+  BarChart3,
+  BriefcaseBusiness,
+  Download,
+  Loader2,
+  Megaphone,
+  Plus,
+  RefreshCw,
+} from "lucide-react"
 import { AppShell } from "@/components/app-shell"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { Progress } from "@/components/ui/progress"
 import { Textarea } from "@/components/ui/textarea"
 import { useAuth } from "@/contexts/auth-context"
 import {
   businessApi,
   type ApiBusinessAccount,
   type ApiBusinessCampaign,
+  type ApiCampaignAnalytics,
+  type ApiCampaignOptionBreakdown,
 } from "@/lib/api"
+import { cn } from "@/lib/utils"
 
 export default function BusinessPage() {
   const router = useRouter()
   const { isAuthenticated, isLoading: authLoading } = useAuth()
   const [accounts, setAccounts] = useState<ApiBusinessAccount[]>([])
   const [campaigns, setCampaigns] = useState<ApiBusinessCampaign[]>([])
+  const [selectedCampaignId, setSelectedCampaignId] = useState<number | null>(null)
+  const [analytics, setAnalytics] = useState<ApiCampaignAnalytics | null>(null)
   const [loading, setLoading] = useState(true)
+  const [analyticsLoading, setAnalyticsLoading] = useState(false)
   const [saving, setSaving] = useState(false)
+  const [exporting, setExporting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [accountName, setAccountName] = useState("")
   const [websiteUrl, setWebsiteUrl] = useState("")
@@ -30,7 +46,7 @@ export default function BusinessPage() {
   const [pollOptions, setPollOptions] = useState("Yes\nNo")
 
   const selectedAccount = accounts[0]
-  const selectedCampaign = campaigns[0]
+  const selectedCampaign = campaigns.find((campaign) => campaign.id === selectedCampaignId) ?? campaigns[0]
 
   const loadBusiness = useCallback(async () => {
     if (!isAuthenticated) return
@@ -44,12 +60,35 @@ export default function BusinessPage() {
       ])
       setAccounts(loadedAccounts)
       setCampaigns(loadedCampaigns)
+      setSelectedCampaignId((current) =>
+        current && loadedCampaigns.some((campaign) => campaign.id === current)
+          ? current
+          : loadedCampaigns[0]?.id ?? null
+      )
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not load business workspace")
     } finally {
       setLoading(false)
     }
   }, [isAuthenticated])
+
+  const loadAnalytics = useCallback(async (campaignId: number | null) => {
+    if (!campaignId) {
+      setAnalytics(null)
+      return
+    }
+
+    setAnalyticsLoading(true)
+    setError(null)
+    try {
+      setAnalytics(await businessApi.getCampaignAnalytics(campaignId))
+    } catch (err) {
+      setAnalytics(null)
+      setError(err instanceof Error ? err.message : "Could not load campaign analytics")
+    } finally {
+      setAnalyticsLoading(false)
+    }
+  }, [])
 
   useEffect(() => {
     if (authLoading) return
@@ -59,6 +98,10 @@ export default function BusinessPage() {
     }
     loadBusiness()
   }, [authLoading, isAuthenticated, loadBusiness, router])
+
+  useEffect(() => {
+    loadAnalytics(selectedCampaignId)
+  }, [loadAnalytics, selectedCampaignId])
 
   const totals = useMemo(() => {
     return campaigns.reduce(
@@ -95,13 +138,14 @@ export default function BusinessPage() {
 
     setSaving(true)
     try {
-      await businessApi.createCampaign(selectedAccount.id, {
+      const created = await businessApi.createCampaign(selectedAccount.id, {
         name: campaignName,
         objective,
         status: "Active",
       })
       setCampaignName("")
       setObjective("")
+      setSelectedCampaignId(created.id)
       await loadBusiness()
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not create campaign")
@@ -123,7 +167,7 @@ export default function BusinessPage() {
     try {
       await businessApi.createSponsoredPoll(selectedCampaign.id, {
         question: pollQuestion,
-        description: objective,
+        description: selectedCampaign.objective,
         category: "General",
         expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
         options,
@@ -132,7 +176,7 @@ export default function BusinessPage() {
       })
       setPollQuestion("")
       setPollOptions("Yes\nNo")
-      await loadBusiness()
+      await Promise.all([loadBusiness(), loadAnalytics(selectedCampaign.id)])
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not create sponsored poll")
     } finally {
@@ -140,9 +184,28 @@ export default function BusinessPage() {
     }
   }
 
+  async function exportCsv() {
+    if (!selectedCampaign) return
+
+    setExporting(true)
+    try {
+      const blob = await businessApi.exportCampaignCsv(selectedCampaign.id)
+      const url = URL.createObjectURL(blob)
+      const link = document.createElement("a")
+      link.href = url
+      link.download = `campaign-${selectedCampaign.id}-analytics.csv`
+      link.click()
+      URL.revokeObjectURL(url)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not export campaign analytics")
+    } finally {
+      setExporting(false)
+    }
+  }
+
   return (
     <AppShell>
-      <main className="mx-auto w-full max-w-5xl px-4 py-6">
+      <main className="mx-auto w-full max-w-6xl px-4 py-6">
         <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
           <div>
             <h1 className="flex items-center gap-2 text-2xl font-bold text-foreground">
@@ -150,13 +213,19 @@ export default function BusinessPage() {
               Business Campaigns
             </h1>
             <p className="text-sm text-muted-foreground">
-              Sponsored polls are labeled clearly and routed through campaign review.
+              Create sponsored polls, review performance, and export campaign results.
             </p>
           </div>
-          <Button className="gap-2" onClick={loadBusiness} variant="outline">
-            <RefreshCw className="h-4 w-4" />
-            Refresh
-          </Button>
+          <div className="flex gap-2">
+            <Button className="gap-2" disabled={!selectedCampaign || exporting} onClick={exportCsv} variant="outline">
+              {exporting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
+              Export CSV
+            </Button>
+            <Button className="gap-2" onClick={loadBusiness} variant="outline">
+              <RefreshCw className="h-4 w-4" />
+              Refresh
+            </Button>
+          </div>
         </div>
 
         {error && (
@@ -170,115 +239,158 @@ export default function BusinessPage() {
             <Loader2 className="h-5 w-5 animate-spin" />
             Loading business workspace...
           </div>
+        ) : accounts.length === 0 ? (
+          <form className="mx-auto max-w-md rounded-lg border border-border/60 bg-card p-4" onSubmit={createAccount}>
+            <h2 className="mb-3 font-semibold text-foreground">Create business account</h2>
+            <div className="space-y-3">
+              <Input
+                onChange={(event) => setAccountName(event.target.value)}
+                placeholder="Business name"
+                required
+                value={accountName}
+              />
+              <Input
+                onChange={(event) => setWebsiteUrl(event.target.value)}
+                placeholder="Website URL"
+                value={websiteUrl}
+              />
+              <Button className="w-full gap-2" disabled={saving}>
+                <Plus className="h-4 w-4" />
+                Create account
+              </Button>
+            </div>
+          </form>
         ) : (
-          <div className="grid gap-4 lg:grid-cols-[1fr_1.2fr]">
-            <section className="space-y-4">
+          <div className="grid gap-4 xl:grid-cols-[280px_1fr]">
+            <aside className="space-y-4">
               <div className="rounded-lg border border-border/60 bg-card p-4">
-                <h2 className="mb-3 font-semibold text-foreground">Account</h2>
-                {selectedAccount ? (
-                  <div className="space-y-1 text-sm">
-                    <p className="font-medium text-foreground">{selectedAccount.name}</p>
-                    <p className="text-muted-foreground">{selectedAccount.websiteUrl ?? "No website"}</p>
-                  </div>
-                ) : (
-                  <form className="space-y-3" onSubmit={createAccount}>
-                    <Input
-                      onChange={(event) => setAccountName(event.target.value)}
-                      placeholder="Business name"
-                      required
-                      value={accountName}
-                    />
-                    <Input
-                      onChange={(event) => setWebsiteUrl(event.target.value)}
-                      placeholder="Website URL"
-                      value={websiteUrl}
-                    />
-                    <Button className="w-full gap-2" disabled={saving}>
-                      <Plus className="h-4 w-4" />
-                      Create account
-                    </Button>
-                  </form>
-                )}
+                <p className="text-xs text-muted-foreground">Account</p>
+                <p className="mt-1 font-semibold text-foreground">{selectedAccount?.name}</p>
+                <p className="text-sm text-muted-foreground">{selectedAccount?.websiteUrl ?? "No website"}</p>
               </div>
 
-              <div className="grid grid-cols-3 gap-2">
+              <div className="grid grid-cols-3 gap-2 xl:grid-cols-1">
                 <Metric label="Impressions" value={totals.impressions} />
                 <Metric label="Votes" value={totals.votes} />
                 <Metric label="Completions" value={totals.completions} />
               </div>
 
-              <div className="rounded-lg border border-border/60 bg-card p-4">
+              <div className="rounded-lg border border-border/60 bg-card p-3">
                 <h2 className="mb-3 font-semibold text-foreground">Campaigns</h2>
                 <div className="space-y-2">
                   {campaigns.map((campaign) => (
-                    <div className="rounded-md border border-border/50 p-3" key={campaign.id}>
+                    <button
+                      className={cn(
+                        "w-full rounded-md border border-border/50 p-3 text-left transition hover:border-primary/40",
+                        selectedCampaign?.id === campaign.id && "border-primary/60 bg-primary/5"
+                      )}
+                      key={campaign.id}
+                      onClick={() => setSelectedCampaignId(campaign.id)}
+                      type="button"
+                    >
                       <div className="flex items-center justify-between gap-3">
                         <p className="font-medium text-foreground">{campaign.name}</p>
                         <span className="rounded-full bg-primary/10 px-2 py-1 text-xs font-semibold text-primary">
                           {campaign.status}
                         </span>
                       </div>
-                      <p className="mt-1 text-sm text-muted-foreground">{campaign.objective}</p>
-                    </div>
+                      <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">{campaign.objective}</p>
+                    </button>
                   ))}
                   {campaigns.length === 0 && (
                     <p className="text-sm text-muted-foreground">No campaigns yet.</p>
                   )}
                 </div>
               </div>
-            </section>
+            </aside>
 
             <section className="space-y-4">
-              <form className="rounded-lg border border-border/60 bg-card p-4" onSubmit={createCampaign}>
-                <h2 className="mb-3 font-semibold text-foreground">New campaign</h2>
-                <div className="space-y-3">
-                  <Input
-                    disabled={!selectedAccount || saving}
-                    onChange={(event) => setCampaignName(event.target.value)}
-                    placeholder="Campaign name"
-                    required
-                    value={campaignName}
-                  />
-                  <Textarea
-                    disabled={!selectedAccount || saving}
-                    onChange={(event) => setObjective(event.target.value)}
-                    placeholder="Objective"
-                    required
-                    value={objective}
-                  />
-                  <Button className="gap-2" disabled={!selectedAccount || saving}>
-                    <Plus className="h-4 w-4" />
-                    Create campaign
-                  </Button>
-                </div>
-              </form>
+              <div className="grid gap-3 md:grid-cols-4">
+                <Metric label="Campaign impressions" value={analytics?.campaign.impressions ?? 0} />
+                <Metric label="Campaign votes" value={analytics?.campaign.votes ?? 0} />
+                <Metric label="Completions" value={analytics?.campaign.completions ?? 0} />
+                <Metric label="Completion rate" value={analytics?.campaign.completionRate ?? 0} suffix="%" />
+              </div>
 
-              <form className="rounded-lg border border-border/60 bg-card p-4" onSubmit={createSponsoredPoll}>
-                <h2 className="mb-3 flex items-center gap-2 font-semibold text-foreground">
-                  <Megaphone className="h-4 w-4 text-amber-500" />
-                  Sponsored poll
-                </h2>
-                <div className="space-y-3">
-                  <Input
-                    disabled={!selectedCampaign || saving}
-                    onChange={(event) => setPollQuestion(event.target.value)}
-                    placeholder="Question"
-                    required
-                    value={pollQuestion}
-                  />
-                  <Textarea
-                    disabled={!selectedCampaign || saving}
-                    onChange={(event) => setPollOptions(event.target.value)}
-                    placeholder="One option per line"
-                    required
-                    value={pollOptions}
-                  />
-                  <Button className="gap-2" disabled={!selectedCampaign || saving}>
-                    {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
-                    Submit for review
-                  </Button>
+              <div className="grid gap-4 lg:grid-cols-[1fr_340px]">
+                <div className="rounded-lg border border-border/60 bg-card p-4">
+                  <div className="mb-3 flex items-center justify-between gap-3">
+                    <h2 className="flex items-center gap-2 font-semibold text-foreground">
+                      <BarChart3 className="h-4 w-4 text-primary" />
+                      Sponsored polls
+                    </h2>
+                    {analyticsLoading && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
+                  </div>
+                  {analytics?.polls.length ? (
+                    <div className="space-y-3">
+                      {analytics.polls.map((poll) => (
+                        <PollAnalyticsRow
+                          key={poll.pollId}
+                          options={analytics.optionBreakdown.filter((option) => option.pollId === poll.pollId)}
+                          poll={poll}
+                        />
+                      ))}
+                    </div>
+                  ) : (
+                    <EmptyState text="No sponsored polls have been submitted for this campaign." />
+                  )}
                 </div>
-              </form>
+
+                <div className="space-y-4">
+                  <form className="rounded-lg border border-border/60 bg-card p-4" onSubmit={createCampaign}>
+                    <h2 className="mb-3 font-semibold text-foreground">New campaign</h2>
+                    <div className="space-y-3">
+                      <Input
+                        disabled={saving}
+                        onChange={(event) => setCampaignName(event.target.value)}
+                        placeholder="Campaign name"
+                        required
+                        value={campaignName}
+                      />
+                      <Textarea
+                        disabled={saving}
+                        onChange={(event) => setObjective(event.target.value)}
+                        placeholder="Objective"
+                        required
+                        value={objective}
+                      />
+                      <Button className="gap-2" disabled={saving}>
+                        <Plus className="h-4 w-4" />
+                        Create campaign
+                      </Button>
+                    </div>
+                  </form>
+
+                  <form className="rounded-lg border border-border/60 bg-card p-4" onSubmit={createSponsoredPoll}>
+                    <h2 className="mb-3 flex items-center gap-2 font-semibold text-foreground">
+                      <Megaphone className="h-4 w-4 text-amber-500" />
+                      Sponsored poll
+                    </h2>
+                    <div className="space-y-3">
+                      <Input
+                        disabled={!selectedCampaign || saving}
+                        onChange={(event) => setPollQuestion(event.target.value)}
+                        placeholder="Question"
+                        required
+                        value={pollQuestion}
+                      />
+                      <Textarea
+                        disabled={!selectedCampaign || saving}
+                        onChange={(event) => setPollOptions(event.target.value)}
+                        placeholder="One option per line"
+                        required
+                        value={pollOptions}
+                      />
+                      <Button className="gap-2" disabled={!selectedCampaign || saving}>
+                        {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+                        Submit for review
+                      </Button>
+                    </div>
+                  </form>
+
+                  <TrendPanel dailyVotes={analytics?.dailyVotes ?? []} />
+                </div>
+              </div>
             </section>
           </div>
         )}
@@ -287,11 +399,99 @@ export default function BusinessPage() {
   )
 }
 
-function Metric({ label, value }: { label: string; value: number }) {
+function Metric({ label, value, suffix = "" }: { label: string; value: number; suffix?: string }) {
   return (
     <div className="rounded-lg border border-border/60 bg-card p-3">
       <p className="text-xs text-muted-foreground">{label}</p>
-      <p className="mt-1 text-lg font-bold text-foreground">{value.toLocaleString()}</p>
+      <p className="mt-1 text-lg font-bold text-foreground">
+        {value.toLocaleString(undefined, { maximumFractionDigits: suffix ? 1 : 0 })}
+        {suffix}
+      </p>
+    </div>
+  )
+}
+
+function PollAnalyticsRow({
+  options,
+  poll,
+}: {
+  options: ApiCampaignOptionBreakdown[]
+  poll: ApiCampaignAnalytics["polls"][number]
+}) {
+  return (
+    <div className="rounded-md border border-border/50 p-3">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="font-medium text-foreground">{poll.question}</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {poll.moderationStatus} - {new Date(poll.createdAt).toLocaleDateString()}
+          </p>
+        </div>
+        <div className="grid grid-cols-4 gap-2 text-right text-xs">
+          <MiniMetric label="Imp." value={poll.impressions} />
+          <MiniMetric label="Votes" value={poll.votes} />
+          <MiniMetric label="Done" value={poll.completions} />
+          <MiniMetric label="Rate" value={`${poll.completionRate.toFixed(1)}%`} />
+        </div>
+      </div>
+      <div className="mt-3 space-y-2">
+        {options.map((option) => (
+          <div key={option.optionId}>
+            <div className="mb-1 flex items-center justify-between gap-3 text-xs">
+              <span className="truncate text-muted-foreground">{option.optionText}</span>
+              <span className="font-medium text-foreground">
+                {option.voteCount} votes - {Math.round(option.votePercentage)}%
+              </span>
+            </div>
+            <Progress value={option.votePercentage} />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function MiniMetric({ label, value }: { label: string; value: number | string }) {
+  return (
+    <div>
+      <p className="text-muted-foreground">{label}</p>
+      <p className="font-semibold text-foreground">{typeof value === "number" ? value.toLocaleString() : value}</p>
+    </div>
+  )
+}
+
+function TrendPanel({ dailyVotes }: { dailyVotes: ApiCampaignAnalytics["dailyVotes"] }) {
+  const maxVotes = Math.max(1, ...dailyVotes.map((day) => day.votes))
+
+  return (
+    <div className="rounded-lg border border-border/60 bg-card p-4">
+      <h2 className="mb-3 font-semibold text-foreground">Vote trend</h2>
+      {dailyVotes.length === 0 ? (
+        <EmptyState text="Trend data appears after sponsored polls receive votes." />
+      ) : (
+        <div className="space-y-2">
+          {dailyVotes.map((day) => (
+            <div className="grid grid-cols-[80px_1fr_40px] items-center gap-2 text-xs" key={day.date}>
+              <span className="text-muted-foreground">{new Date(day.date).toLocaleDateString()}</span>
+              <div className="h-2 overflow-hidden rounded-full bg-secondary">
+                <div
+                  className="h-full rounded-full bg-primary"
+                  style={{ width: `${Math.max(4, (day.votes / maxVotes) * 100)}%` }}
+                />
+              </div>
+              <span className="text-right font-medium text-foreground">{day.votes}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function EmptyState({ text }: { text: string }) {
+  return (
+    <div className="rounded-md border border-dashed border-border/70 px-4 py-8 text-center text-sm text-muted-foreground">
+      {text}
     </div>
   )
 }

--- a/Frontend/lib/api.ts
+++ b/Frontend/lib/api.ts
@@ -145,6 +145,39 @@ export interface ApiBusinessCampaign {
   completionRate: number
 }
 
+export interface ApiCampaignPollMetric {
+  campaignId: number
+  pollId: number
+  question: string
+  moderationStatus: string
+  createdAt: string
+  impressions: number
+  votes: number
+  completions: number
+  completionRate: number
+  updatedAt: string
+}
+
+export interface ApiCampaignOptionBreakdown {
+  pollId: number
+  optionId: number
+  optionText: string
+  voteCount: number
+  votePercentage: number
+}
+
+export interface ApiCampaignDailyMetric {
+  date: string
+  votes: number
+}
+
+export interface ApiCampaignAnalytics {
+  campaign: ApiBusinessCampaign
+  polls: ApiCampaignPollMetric[]
+  optionBreakdown: ApiCampaignOptionBreakdown[]
+  dailyVotes: ApiCampaignDailyMetric[]
+}
+
 export interface CreateBusinessAccountPayload {
   name: string
   websiteUrl?: string
@@ -268,6 +301,22 @@ export const businessApi = {
     }),
 
   getCampaigns: () => request<ApiBusinessCampaign[]>("/api/business/campaigns"),
+
+  getCampaignAnalytics: (campaignId: number) =>
+    request<ApiCampaignAnalytics>(`/api/business/campaigns/${campaignId}/analytics`),
+
+  exportCampaignCsv: async (campaignId: number) => {
+    const res = await fetch(`${API_BASE_URL}/api/business/campaigns/${campaignId}/export.csv`, {
+      headers: authHeaders(),
+    })
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => res.statusText)
+      throw new Error(`API ${res.status}: ${text}`)
+    }
+
+    return res.blob()
+  },
 
   createCampaign: (businessId: number, payload: CreateBusinessCampaignPayload) =>
     request<ApiBusinessCampaign>(`/api/business/accounts/${businessId}/campaigns`, {


### PR DESCRIPTION
## Summary
- Add owner-scoped campaign analytics API with sponsored poll metrics, option breakdowns, and daily vote trend data
- Add authenticated CSV export for campaign poll performance and option results
- Upgrade the `/business` page into an analytics dashboard with campaign selection, totals, poll-level metrics, breakdown bars, trend view, export, and empty/loading/error states
- Keep analytics access restricted through the existing business ownership checks

## Verification
- `dotnet build`
- `./node_modules/.bin/tsc --noEmit` from `Frontend`
- `git diff --check`
- `npm run build`
- `npm run lint` could not complete because `eslint` is not installed in `Frontend`

Closes #60