### PR TITLE
Add private wellness poll mode

### DIFF
--- a/Backend/BackendAPI/Controllers/VotesController.cs
+++ b/Backend/BackendAPI/Controllers/VotesController.cs
@@ -56,6 +56,9 @@ namespace BackendAPI.Controllers
             if (!poll.ModerationStatus.Equals(PollModerationStatus.Published, StringComparison.OrdinalIgnoreCase))
                 return BadRequest(new { message = "This poll is not open for voting." });
 
+            if (poll.IsWellness || poll.IsPrivate || poll.Category.Equals("Health", StringComparison.OrdinalIgnoreCase))
+                return BadRequest(new { message = "Health and wellness check-ins use private wellness responses." });
+
             var validOption = poll.Options.Any(o => o.Id == request.OptionId);
             if (!validOption)
                 return BadRequest(new { message = "Invalid option for this poll." });

--- a/Backend/BackendAPI/Controllers/WellnessController.cs
+++ b/Backend/BackendAPI/Controllers/WellnessController.cs
@@ -1,0 +1,100 @@
+using BackendAPI.Interfaces;
+using BackendAPI.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using System.Text;
+
+namespace BackendAPI.Controllers
+{
+    [ApiController]
+    [Authorize]
+    [Route("api/[controller]")]
+    public class WellnessController : ControllerBase
+    {
+        private readonly IWellnessRepository _wellnessRepo;
+
+        public WellnessController(IWellnessRepository wellnessRepo)
+        {
+            _wellnessRepo = wellnessRepo;
+        }
+
+        private long? CurrentUserId()
+        {
+            var claim = User.FindFirst(ClaimTypes.NameIdentifier) ?? User.FindFirst("sub");
+            return claim != null && long.TryParse(claim.Value, out var id) ? id : null;
+        }
+
+        [HttpGet("overview")]
+        public async Task<IActionResult> GetOverview()
+        {
+            var userId = CurrentUserId();
+            if (userId == null) return Unauthorized(new { message = "Invalid token." });
+
+            return Ok(await _wellnessRepo.GetOverviewAsync(userId.Value));
+        }
+
+        [HttpPost("responses")]
+        public async Task<IActionResult> CreateResponse([FromBody] CreateWellnessResponseRequest request)
+        {
+            var userId = CurrentUserId();
+            if (userId == null) return Unauthorized(new { message = "Invalid token." });
+
+            var response = await _wellnessRepo.CreateResponseAsync(userId.Value, request);
+            return response == null
+                ? NotFound(new { message = "Wellness poll or option not found." })
+                : Ok(response);
+        }
+
+        [HttpGet("history")]
+        public async Task<IActionResult> GetHistory([FromQuery] int count = 30)
+        {
+            var userId = CurrentUserId();
+            if (userId == null) return Unauthorized(new { message = "Invalid token." });
+
+            var history = await _wellnessRepo.GetHistoryAsync(userId.Value, Math.Clamp(count, 1, 100));
+            return Ok(history);
+        }
+
+        [HttpGet("export.csv")]
+        public async Task<IActionResult> Export()
+        {
+            var userId = CurrentUserId();
+            if (userId == null) return Unauthorized(new { message = "Invalid token." });
+
+            var history = await _wellnessRepo.GetHistoryAsync(userId.Value, 500);
+            var csv = new StringBuilder();
+            csv.AppendLine("Question,Response,Note,CreatedAt");
+
+            foreach (var item in history)
+            {
+                csv.AppendLine(string.Join(",",
+                    Csv(item.Question),
+                    Csv(item.OptionText),
+                    Csv(item.Note),
+                    item.CreatedAt.ToString("O")));
+            }
+
+            return File(
+                Encoding.UTF8.GetBytes(csv.ToString()),
+                "text/csv",
+                "wellness-responses.csv");
+        }
+
+        [HttpDelete("responses")]
+        public async Task<IActionResult> DeleteResponses()
+        {
+            var userId = CurrentUserId();
+            if (userId == null) return Unauthorized(new { message = "Invalid token." });
+
+            await _wellnessRepo.DeleteResponsesAsync(userId.Value);
+            return NoContent();
+        }
+
+        private static string Csv(string? value)
+        {
+            var text = value ?? string.Empty;
+            return $"\"{text.Replace("\"", "\"\"")}\"";
+        }
+    }
+}

--- a/Backend/BackendAPI/Interfaces/IWellnessRepository.cs
+++ b/Backend/BackendAPI/Interfaces/IWellnessRepository.cs
@@ -1,0 +1,14 @@
+using BackendAPI.Models;
+
+namespace BackendAPI.Interfaces
+{
+    public interface IWellnessRepository
+    {
+        Task<IEnumerable<Poll>> GetActivePollsAsync(long userId);
+        Task<WellnessOverview> GetOverviewAsync(long userId);
+        Task<WellnessResponse?> CreateResponseAsync(long userId, CreateWellnessResponseRequest request);
+        Task<IEnumerable<WellnessResponse>> GetHistoryAsync(long userId, int count = 30);
+        Task<WellnessInsight> GetInsightAsync(long userId);
+        Task DeleteResponsesAsync(long userId);
+    }
+}

--- a/Backend/BackendAPI/Migrations/US61_Private_Wellness_Mode.sql
+++ b/Backend/BackendAPI/Migrations/US61_Private_Wellness_Mode.sql
@@ -1,0 +1,112 @@
+IF COL_LENGTH('dbo.Polls', 'IsPrivate') IS NULL
+BEGIN
+    ALTER TABLE dbo.Polls ADD IsPrivate BIT NOT NULL CONSTRAINT DF_Polls_IsPrivate DEFAULT 0;
+END;
+
+IF COL_LENGTH('dbo.Polls', 'IsWellness') IS NULL
+BEGIN
+    ALTER TABLE dbo.Polls ADD IsWellness BIT NOT NULL CONSTRAINT DF_Polls_IsWellness DEFAULT 0;
+END;
+
+IF COL_LENGTH('dbo.Polls', 'PollMode') IS NULL
+BEGIN
+    ALTER TABLE dbo.Polls ADD PollMode NVARCHAR(40) NOT NULL CONSTRAINT DF_Polls_PollMode DEFAULT 'Public';
+END;
+
+UPDATE dbo.Polls
+SET IsPrivate = 1,
+    IsWellness = 1,
+    PollMode = 'Wellness',
+    ModerationStatus = 'Published'
+WHERE Category = 'Health';
+
+IF OBJECT_ID('dbo.WellnessResponses', 'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.WellnessResponses (
+        Id BIGINT IDENTITY(1,1) PRIMARY KEY,
+        UserId BIGINT NOT NULL,
+        PollId BIGINT NOT NULL,
+        OptionId BIGINT NOT NULL,
+        Note NVARCHAR(500) NULL,
+        CreatedAt DATETIME2 NOT NULL CONSTRAINT DF_WellnessResponses_CreatedAt DEFAULT GETUTCDATE(),
+        CONSTRAINT FK_WellnessResponses_Users FOREIGN KEY (UserId) REFERENCES dbo.Users(Id),
+        CONSTRAINT FK_WellnessResponses_Polls FOREIGN KEY (PollId) REFERENCES dbo.Polls(Id),
+        CONSTRAINT FK_WellnessResponses_PollOptions FOREIGN KEY (OptionId) REFERENCES dbo.PollOptions(Id)
+    );
+END;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE name = 'IX_WellnessResponses_User_CreatedAt'
+      AND object_id = OBJECT_ID('dbo.WellnessResponses')
+)
+BEGIN
+    CREATE INDEX IX_WellnessResponses_User_CreatedAt
+    ON dbo.WellnessResponses (UserId, CreatedAt DESC);
+END;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE name = 'IX_Polls_Wellness_Private'
+      AND object_id = OBJECT_ID('dbo.Polls')
+)
+BEGIN
+    CREATE INDEX IX_Polls_Wellness_Private
+    ON dbo.Polls (IsWellness, IsPrivate, IsActive, ExpiresAt);
+END;
+
+IF NOT EXISTS (
+    SELECT 1 FROM dbo.Polls
+    WHERE PollMode = 'Wellness'
+      AND Question = 'How are you feeling today?'
+)
+BEGIN
+    DECLARE @MoodPollId BIGINT;
+
+    INSERT INTO dbo.Polls
+        (Question, Description, Category, ExpiresAt, IsActive, IsTrending, CreatedByUserId,
+         CreatedAt, TotalVotes, SourceType, SourceUrl, ThumbnailUrl, IsAIGenerated,
+         IsPrivate, IsWellness, PollMode, ModerationStatus, ReportCount)
+    VALUES
+        ('How are you feeling today?', 'Private daily wellness check-in.', 'Health',
+         DATEADD(year, 5, GETUTCDATE()), 1, 0, NULL,
+         GETUTCDATE(), 0, 'manual', NULL, NULL, 0,
+         1, 1, 'Wellness', 'Published', 0);
+
+    SET @MoodPollId = CAST(SCOPE_IDENTITY() AS BIGINT);
+
+    INSERT INTO dbo.PollOptions (PollId, Text, VoteCount, VotePercentage)
+    VALUES
+        (@MoodPollId, 'Great', 0, 0),
+        (@MoodPollId, 'Okay', 0, 0),
+        (@MoodPollId, 'Stressed', 0, 0),
+        (@MoodPollId, 'Low', 0, 0);
+END;
+
+IF NOT EXISTS (
+    SELECT 1 FROM dbo.Polls
+    WHERE PollMode = 'Wellness'
+      AND Question = 'What does your body need right now?'
+)
+BEGIN
+    DECLARE @BodyPollId BIGINT;
+
+    INSERT INTO dbo.Polls
+        (Question, Description, Category, ExpiresAt, IsActive, IsTrending, CreatedByUserId,
+         CreatedAt, TotalVotes, SourceType, SourceUrl, ThumbnailUrl, IsAIGenerated,
+         IsPrivate, IsWellness, PollMode, ModerationStatus, ReportCount)
+    VALUES
+        ('What does your body need right now?', 'Private wellness reflection.', 'Health',
+         DATEADD(year, 5, GETUTCDATE()), 1, 0, NULL,
+         GETUTCDATE(), 0, 'manual', NULL, NULL, 0,
+         1, 1, 'Wellness', 'Published', 0);
+
+    SET @BodyPollId = CAST(SCOPE_IDENTITY() AS BIGINT);
+
+    INSERT INTO dbo.PollOptions (PollId, Text, VoteCount, VotePercentage)
+    VALUES
+        (@BodyPollId, 'Rest', 0, 0),
+        (@BodyPollId, 'Water', 0, 0),
+        (@BodyPollId, 'Movement', 0, 0),
+        (@BodyPollId, 'A calmer moment', 0, 0);
+END;

--- a/Backend/BackendAPI/Models/Poll.cs
+++ b/Backend/BackendAPI/Models/Poll.cs
@@ -19,6 +19,9 @@ namespace BackendAPI.Models
         public long? CampaignId { get; set; }
         public string? SponsorName { get; set; }
         public string? CampaignName { get; set; }
+        public bool IsPrivate { get; set; }
+        public bool IsWellness { get; set; }
+        public string PollMode { get; set; } = PollModes.Public;
         public string ModerationStatus { get; set; } = PollModerationStatus.Published;
         public string? ModerationReason { get; set; }
         public long? ModeratedByUserId { get; set; }
@@ -67,6 +70,14 @@ namespace BackendAPI.Models
         public string? SourceUrl { get; set; }
         public string? ThumbnailUrl { get; set; }
         public bool IsAIGenerated { get; set; }
+        public bool IsPrivate { get; set; }
+        public bool IsWellness { get; set; }
+    }
+
+    public static class PollModes
+    {
+        public const string Public = "Public";
+        public const string Wellness = "Wellness";
     }
 
     // ── TrendingTopics staging table model (US-01) ───────────────────────────

--- a/Backend/BackendAPI/Models/Wellness.cs
+++ b/Backend/BackendAPI/Models/Wellness.cs
@@ -1,0 +1,35 @@
+namespace BackendAPI.Models
+{
+    public class WellnessResponse
+    {
+        public long Id { get; set; }
+        public long UserId { get; set; }
+        public long PollId { get; set; }
+        public long OptionId { get; set; }
+        public string Question { get; set; } = string.Empty;
+        public string OptionText { get; set; } = string.Empty;
+        public string? Note { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+
+    public class WellnessInsight
+    {
+        public int TotalCheckIns { get; set; }
+        public DateTime? LastCheckInAt { get; set; }
+        public string? MostCommonResponse { get; set; }
+    }
+
+    public class WellnessOverview
+    {
+        public IEnumerable<Poll> Polls { get; set; } = Enumerable.Empty<Poll>();
+        public IEnumerable<WellnessResponse> History { get; set; } = Enumerable.Empty<WellnessResponse>();
+        public WellnessInsight Insight { get; set; } = new();
+    }
+
+    public class CreateWellnessResponseRequest
+    {
+        public long PollId { get; set; }
+        public long OptionId { get; set; }
+        public string? Note { get; set; }
+    }
+}

--- a/Backend/BackendAPI/Program.cs
+++ b/Backend/BackendAPI/Program.cs
@@ -62,6 +62,7 @@ builder.Services.AddScoped<IDashboardRepository,     DashboardRepository>();
 builder.Services.AddScoped<ITrendingTopicRepository, TrendingTopicRepository>();
 builder.Services.AddScoped<IChallengesRepository,    ChallengesRepository>();
 builder.Services.AddScoped<IBusinessRepository,      BusinessRepository>();
+builder.Services.AddScoped<IWellnessRepository,      WellnessRepository>();
 
 // ── Ingestion Services (US-03, US-04, US-05) ──────────────────────────────
 builder.Services.AddHttpClient();

--- a/Backend/BackendAPI/Repository/PollsRepository.cs
+++ b/Backend/BackendAPI/Repository/PollsRepository.cs
@@ -73,6 +73,8 @@ namespace BackendAPI.Repository
                   LEFT JOIN PollOptions o ON o.PollId = p.Id
                   WHERE p.IsActive = 1
                     AND p.ModerationStatus = 'Published'
+                    AND COALESCE(p.IsPrivate, 0) = 0
+                    AND COALESCE(p.IsWellness, 0) = 0
                     AND (@Category IS NULL OR LOWER(p.Category) = LOWER(@Category))
                   ORDER BY p.CreatedAt DESC",
                 (poll, option) =>
@@ -109,7 +111,8 @@ namespace BackendAPI.Repository
                   LEFT JOIN BusinessAccounts b ON b.Id = p.BusinessId
                   LEFT JOIN BusinessCampaigns c ON c.Id = p.CampaignId
                   LEFT JOIN PollOptions o ON o.PollId = p.Id
-                  WHERE p.Id = @Id",
+                  WHERE p.Id = @Id
+                    AND (COALESCE(p.IsPrivate, 0) = 0 OR p.CreatedByUserId = @UserId)",
                 (poll, option) =>
                 {
                     if (!pollDict.TryGetValue(poll.Id, out var existing))
@@ -121,7 +124,7 @@ namespace BackendAPI.Repository
                     if (option != null) existing.Options.Add(option);
                     return existing;
                 },
-                new { Id = id },
+                new { Id = id, UserId = userId },
                 splitOn: "Id"
             );
 
@@ -148,6 +151,8 @@ namespace BackendAPI.Repository
                   LEFT JOIN PollOptions o ON o.PollId = p.Id
                   WHERE p.IsActive = 1
                     AND p.ModerationStatus = 'Published'
+                    AND COALESCE(p.IsPrivate, 0) = 0
+                    AND COALESCE(p.IsWellness, 0) = 0
                     AND (@Category IS NULL OR LOWER(p.Category) = LOWER(@Category))
                   ORDER BY p.TotalVotes DESC, p.CreatedAt DESC",
                 (poll, option) =>
@@ -213,6 +218,8 @@ namespace BackendAPI.Repository
                       ON LOWER(activity.Category) = LOWER(p.Category)
                     WHERE p.IsActive = 1
                       AND p.ModerationStatus = 'Published'
+                      AND COALESCE(p.IsPrivate, 0) = 0
+                      AND COALESCE(p.IsWellness, 0) = 0
                       AND (@Category IS NULL OR LOWER(p.Category) = LOWER(@Category))
                     ORDER BY PersonalizationScore DESC, p.TotalVotes DESC, p.CreatedAt DESC
                   )
@@ -255,6 +262,8 @@ namespace BackendAPI.Repository
                     FROM Polls p
                     WHERE p.IsActive = 1
                       AND p.ModerationStatus = 'Published'
+                      AND COALESCE(p.IsPrivate, 0) = 0
+                      AND COALESCE(p.IsWellness, 0) = 0
                       AND p.Question LIKE @Search
                       AND (@Category IS NULL OR LOWER(p.Category) = LOWER(@Category))
                     ORDER BY p.TotalVotes DESC, p.CreatedAt DESC
@@ -301,6 +310,8 @@ namespace BackendAPI.Repository
                   LEFT JOIN PollOptions o ON o.PollId = p.Id
                   WHERE p.IsActive = 1
                     AND p.ModerationStatus = 'Published'
+                    AND COALESCE(p.IsPrivate, 0) = 0
+                    AND COALESCE(p.IsWellness, 0) = 0
                   ORDER BY p.CreatedAt DESC",
                 (poll, option) =>
                 {
@@ -366,7 +377,12 @@ namespace BackendAPI.Repository
             conn.Open();
             using var transaction = conn.BeginTransaction();
             var normalizedCategory = CategoryCatalog.NormalizeName(request.Category);
-            var moderationStatus = PollModerationStatus.PendingReview;
+            var isWellness = request.IsWellness || normalizedCategory.Equals("Health", StringComparison.OrdinalIgnoreCase);
+            var isPrivate = request.IsPrivate || isWellness;
+            var pollMode = isWellness ? PollModes.Wellness : PollModes.Public;
+            var moderationStatus = isWellness
+                ? PollModerationStatus.Published
+                : PollModerationStatus.PendingReview;
 
             try
             {
@@ -375,11 +391,13 @@ namespace BackendAPI.Repository
                         (Question, Description, Category, ExpiresAt, IsActive, IsTrending,
                          CreatedByUserId,
                          CreatedAt, TotalVotes, SourceType, SourceUrl, ThumbnailUrl, IsAIGenerated,
+                         IsPrivate, IsWellness, PollMode,
                          ModerationStatus, ModerationReason, ModeratedByUserId, ModeratedAt, ReportCount, LastReportedAt)
                       VALUES
                         (@Question, @Description, @Category, @ExpiresAt, 1, 0,
                          @CreatedByUserId,
                          GETUTCDATE(), 0, @SourceType, @SourceUrl, @ThumbnailUrl, @IsAIGenerated,
+                         @IsPrivate, @IsWellness, @PollMode,
                          @ModerationStatus, NULL, NULL, NULL, 0, NULL);
                       SELECT CAST(SCOPE_IDENTITY() AS BIGINT);",
                     new
@@ -392,6 +410,9 @@ namespace BackendAPI.Repository
                         request.SourceUrl,
                         request.ThumbnailUrl,
                         request.IsAIGenerated,
+                        IsPrivate = isPrivate,
+                        IsWellness = isWellness,
+                        PollMode = pollMode,
                         ModerationStatus = moderationStatus,
                         CreatedByUserId = createdByUserId
                     },

--- a/Backend/BackendAPI/Repository/UsersRepository.cs
+++ b/Backend/BackendAPI/Repository/UsersRepository.cs
@@ -116,6 +116,9 @@ namespace BackendAPI.Repository
                   JOIN Polls       p ON p.Id = v.PollId
                   JOIN PollOptions o ON o.Id = v.OptionId
                   WHERE v.UserId = @UserId
+                    AND COALESCE(p.IsPrivate, 0) = 0
+                    AND COALESCE(p.IsWellness, 0) = 0
+                    AND p.Category <> 'Health'
                   ORDER BY v.CreatedAt DESC",
                 new { UserId = userId, Count = count }
             );

--- a/Backend/BackendAPI/Repository/WellnessRepository.cs
+++ b/Backend/BackendAPI/Repository/WellnessRepository.cs
@@ -1,0 +1,189 @@
+using BackendAPI.Data;
+using BackendAPI.Interfaces;
+using BackendAPI.Models;
+using Dapper;
+
+namespace BackendAPI.Repository
+{
+    public class WellnessRepository : IWellnessRepository
+    {
+        private readonly DapperContext _context;
+
+        public WellnessRepository(DapperContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<IEnumerable<Poll>> GetActivePollsAsync(long userId)
+        {
+            using var conn = _context.CreateConnection();
+            var pollDict = new Dictionary<long, Poll>();
+
+            await conn.QueryAsync<Poll, PollOption, Poll>(
+                @"SELECT p.*, o.*
+                  FROM Polls p
+                  LEFT JOIN PollOptions o ON o.PollId = p.Id
+                  WHERE p.IsActive = 1
+                    AND p.IsWellness = 1
+                    AND p.IsPrivate = 1
+                    AND (p.CreatedByUserId IS NULL OR p.CreatedByUserId = @UserId)
+                    AND p.ExpiresAt > GETUTCDATE()
+                  ORDER BY p.CreatedAt DESC",
+                (poll, option) =>
+                {
+                    if (!pollDict.TryGetValue(poll.Id, out var existing))
+                    {
+                        existing = poll;
+                        existing.Options = new List<PollOption>();
+                        pollDict[poll.Id] = existing;
+                    }
+                    if (option != null) existing.Options.Add(option);
+                    return existing;
+                },
+                new { UserId = userId },
+                splitOn: "Id");
+
+            return pollDict.Values;
+        }
+
+        public async Task<WellnessOverview> GetOverviewAsync(long userId)
+        {
+            return new WellnessOverview
+            {
+                Polls = await GetActivePollsAsync(userId),
+                History = await GetHistoryAsync(userId, 10),
+                Insight = await GetInsightAsync(userId)
+            };
+        }
+
+        public async Task<WellnessResponse?> CreateResponseAsync(
+            long userId,
+            CreateWellnessResponseRequest request)
+        {
+            using var conn = _context.CreateConnection();
+            conn.Open();
+            using var transaction = conn.BeginTransaction();
+
+            try
+            {
+                var pollOption = await conn.QuerySingleOrDefaultAsync<WellnessPollOption>(
+                    @"SELECT
+                          p.Id AS PollId,
+                          p.Question,
+                          o.Id AS OptionId,
+                          o.Text AS OptionText
+                      FROM Polls p
+                      JOIN PollOptions o ON o.PollId = p.Id
+                      WHERE p.Id = @PollId
+                        AND o.Id = @OptionId
+                        AND p.IsActive = 1
+                        AND p.IsWellness = 1
+                        AND p.IsPrivate = 1
+                        AND p.ExpiresAt > GETUTCDATE()
+                        AND (p.CreatedByUserId IS NULL OR p.CreatedByUserId = @UserId)",
+                    new { request.PollId, request.OptionId, UserId = userId },
+                    transaction);
+
+                if (pollOption == null)
+                {
+                    transaction.Rollback();
+                    return null;
+                }
+
+                var id = await conn.ExecuteScalarAsync<long>(
+                    @"INSERT INTO WellnessResponses
+                        (UserId, PollId, OptionId, Note, CreatedAt)
+                      VALUES
+                        (@UserId, @PollId, @OptionId, @Note, GETUTCDATE());
+                      SELECT CAST(SCOPE_IDENTITY() AS BIGINT);",
+                    new
+                    {
+                        UserId = userId,
+                        request.PollId,
+                        request.OptionId,
+                        Note = string.IsNullOrWhiteSpace(request.Note) ? null : request.Note.Trim()
+                    },
+                    transaction);
+
+                transaction.Commit();
+
+                return new WellnessResponse
+                {
+                    Id = id,
+                    UserId = userId,
+                    PollId = pollOption.PollId,
+                    OptionId = pollOption.OptionId,
+                    Question = pollOption.Question,
+                    OptionText = pollOption.OptionText,
+                    Note = string.IsNullOrWhiteSpace(request.Note) ? null : request.Note.Trim(),
+                    CreatedAt = DateTime.UtcNow
+                };
+            }
+            catch
+            {
+                transaction.Rollback();
+                throw;
+            }
+        }
+
+        public async Task<IEnumerable<WellnessResponse>> GetHistoryAsync(long userId, int count = 30)
+        {
+            using var conn = _context.CreateConnection();
+            return await conn.QueryAsync<WellnessResponse>(
+                @"SELECT TOP (@Count)
+                      wr.Id,
+                      wr.UserId,
+                      wr.PollId,
+                      wr.OptionId,
+                      p.Question,
+                      o.Text AS OptionText,
+                      wr.Note,
+                      wr.CreatedAt
+                  FROM WellnessResponses wr
+                  JOIN Polls p ON p.Id = wr.PollId
+                  JOIN PollOptions o ON o.Id = wr.OptionId
+                  WHERE wr.UserId = @UserId
+                  ORDER BY wr.CreatedAt DESC",
+                new { UserId = userId, Count = count });
+        }
+
+        public async Task<WellnessInsight> GetInsightAsync(long userId)
+        {
+            using var conn = _context.CreateConnection();
+            var summary = await conn.QuerySingleAsync<WellnessInsight>(
+                @"SELECT
+                      COUNT(1) AS TotalCheckIns,
+                      MAX(CreatedAt) AS LastCheckInAt
+                  FROM WellnessResponses
+                  WHERE UserId = @UserId",
+                new { UserId = userId });
+
+            summary.MostCommonResponse = await conn.ExecuteScalarAsync<string?>(
+                @"SELECT TOP (1) o.Text
+                  FROM WellnessResponses wr
+                  JOIN PollOptions o ON o.Id = wr.OptionId
+                  WHERE wr.UserId = @UserId
+                  GROUP BY o.Text
+                  ORDER BY COUNT(1) DESC, o.Text ASC",
+                new { UserId = userId });
+
+            return summary;
+        }
+
+        public async Task DeleteResponsesAsync(long userId)
+        {
+            using var conn = _context.CreateConnection();
+            await conn.ExecuteAsync(
+                "DELETE FROM WellnessResponses WHERE UserId = @UserId",
+                new { UserId = userId });
+        }
+
+        private class WellnessPollOption
+        {
+            public long PollId { get; set; }
+            public string Question { get; set; } = string.Empty;
+            public long OptionId { get; set; }
+            public string OptionText { get; set; } = string.Empty;
+        }
+    }
+}

--- a/Frontend/app/wellness/page.tsx
+++ b/Frontend/app/wellness/page.tsx
@@ -1,0 +1,257 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { useRouter } from "next/navigation"
+import { Download, HeartPulse, Loader2, RefreshCw, ShieldCheck, Trash2 } from "lucide-react"
+import { AppShell } from "@/components/app-shell"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { useAuth } from "@/contexts/auth-context"
+import { wellnessApi, type ApiPoll, type ApiWellnessOverview } from "@/lib/api"
+
+export default function WellnessPage() {
+  const router = useRouter()
+  const { isAuthenticated, isLoading: authLoading } = useAuth()
+  const [overview, setOverview] = useState<ApiWellnessOverview | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [savingOptionId, setSavingOptionId] = useState<number | null>(null)
+  const [exporting, setExporting] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [noteByPoll, setNoteByPoll] = useState<Record<number, string>>({})
+  const [error, setError] = useState<string | null>(null)
+
+  const loadOverview = useCallback(async () => {
+    if (!isAuthenticated) return
+
+    setLoading(true)
+    setError(null)
+    try {
+      setOverview(await wellnessApi.getOverview())
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not load wellness mode")
+    } finally {
+      setLoading(false)
+    }
+  }, [isAuthenticated])
+
+  useEffect(() => {
+    if (authLoading) return
+    if (!isAuthenticated) {
+      router.push("/login?message=Sign in to use private wellness mode&redirect=/wellness")
+      return
+    }
+    loadOverview()
+  }, [authLoading, isAuthenticated, loadOverview, router])
+
+  const latestResponse = overview?.history[0]
+  const insight = overview?.insight
+  const checkInCount = insight?.totalCheckIns ?? 0
+
+  const consentPoints = useMemo(() => [
+    "Your wellness responses stay out of public feeds, leaderboards, result cards, and share previews.",
+    "Wellness check-ins are stored separately from public poll votes.",
+    "You can export or delete your wellness response history at any time.",
+  ], [])
+
+  async function answer(poll: ApiPoll, optionId: number) {
+    setSavingOptionId(optionId)
+    setError(null)
+    try {
+      await wellnessApi.createResponse(poll.id, optionId, noteByPoll[poll.id])
+      setNoteByPoll((current) => ({ ...current, [poll.id]: "" }))
+      await loadOverview()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not save check-in")
+    } finally {
+      setSavingOptionId(null)
+    }
+  }
+
+  async function exportCsv() {
+    setExporting(true)
+    setError(null)
+    try {
+      const blob = await wellnessApi.exportCsv()
+      const url = URL.createObjectURL(blob)
+      const link = document.createElement("a")
+      link.href = url
+      link.download = "wellness-responses.csv"
+      link.click()
+      URL.revokeObjectURL(url)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not export wellness data")
+    } finally {
+      setExporting(false)
+    }
+  }
+
+  async function deleteResponses() {
+    setDeleting(true)
+    setError(null)
+    try {
+      await wellnessApi.deleteResponses()
+      await loadOverview()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not delete wellness responses")
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  return (
+    <AppShell>
+      <main className="mx-auto w-full max-w-4xl px-4 py-6">
+        <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h1 className="flex items-center gap-2 text-2xl font-bold text-foreground">
+              <HeartPulse className="h-6 w-6 text-rose-500" />
+              Private Wellness
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              Personal check-ins for reflection, not public competition.
+            </p>
+          </div>
+          <Button className="gap-2" onClick={loadOverview} variant="outline">
+            <RefreshCw className="h-4 w-4" />
+            Refresh
+          </Button>
+        </div>
+
+        {error && (
+          <div className="mb-4 rounded-lg border border-destructive/20 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            {error}
+          </div>
+        )}
+
+        <section className="mb-5 rounded-lg border border-rose-500/20 bg-rose-500/10 p-4">
+          <div className="flex gap-3">
+            <ShieldCheck className="mt-0.5 h-5 w-5 flex-shrink-0 text-rose-600" />
+            <div>
+              <h2 className="font-semibold text-foreground">Privacy and consent</h2>
+              <div className="mt-2 space-y-1 text-sm text-muted-foreground">
+                {consentPoints.map((point) => (
+                  <p key={point}>{point}</p>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {loading ? (
+          <div className="flex items-center justify-center gap-3 py-20 text-muted-foreground">
+            <Loader2 className="h-5 w-5 animate-spin" />
+            Loading wellness mode...
+          </div>
+        ) : (
+          <div className="grid gap-4 lg:grid-cols-[1fr_280px]">
+            <section className="space-y-4">
+              {overview?.polls.length ? (
+                overview.polls.map((poll) => (
+                  <div className="rounded-lg border border-border/60 bg-card p-4" key={poll.id}>
+                    <div className="mb-3">
+                      <p className="text-xs font-semibold uppercase text-rose-600">Private check-in</p>
+                      <h2 className="mt-1 text-lg font-bold text-foreground">{poll.question}</h2>
+                      {poll.description && (
+                        <p className="mt-1 text-sm text-muted-foreground">{poll.description}</p>
+                      )}
+                    </div>
+
+                    <div className="grid gap-2 sm:grid-cols-2">
+                      {poll.options.map((option) => (
+                        <Button
+                          className="min-h-12 justify-start rounded-lg"
+                          disabled={savingOptionId != null}
+                          key={option.id}
+                          onClick={() => answer(poll, option.id)}
+                          variant="outline"
+                        >
+                          {savingOptionId === option.id ? (
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          ) : null}
+                          {option.text}
+                        </Button>
+                      ))}
+                    </div>
+
+                    <Textarea
+                      className="mt-3"
+                      onChange={(event) =>
+                        setNoteByPoll((current) => ({ ...current, [poll.id]: event.target.value }))
+                      }
+                      placeholder="Optional private note"
+                      value={noteByPoll[poll.id] ?? ""}
+                    />
+                  </div>
+                ))
+              ) : (
+                <div className="rounded-lg border border-dashed border-border/70 px-4 py-12 text-center text-sm text-muted-foreground">
+                  No wellness check-ins are active yet.
+                </div>
+              )}
+            </section>
+
+            <aside className="space-y-4">
+              <div className="rounded-lg border border-border/60 bg-card p-4">
+                <h2 className="font-semibold text-foreground">Personal insight</h2>
+                <div className="mt-3 grid grid-cols-2 gap-2 text-sm">
+                  <Metric label="Check-ins" value={String(checkInCount)} />
+                  <Metric
+                    label="Common"
+                    value={insight?.mostCommonResponse ?? "None"}
+                  />
+                </div>
+                <p className="mt-3 text-xs text-muted-foreground">
+                  {latestResponse
+                    ? `Last check-in: ${new Date(latestResponse.createdAt).toLocaleString()}`
+                    : "Your first check-in will appear here."}
+                </p>
+              </div>
+
+              <div className="rounded-lg border border-border/60 bg-card p-4">
+                <h2 className="font-semibold text-foreground">Your data</h2>
+                <div className="mt-3 flex flex-col gap-2">
+                  <Button className="gap-2" disabled={exporting || checkInCount === 0} onClick={exportCsv} variant="outline">
+                    {exporting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
+                    Export CSV
+                  </Button>
+                  <Button className="gap-2" disabled={deleting || checkInCount === 0} onClick={deleteResponses} variant="destructive">
+                    {deleting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+                    Delete history
+                  </Button>
+                </div>
+              </div>
+
+              <div className="rounded-lg border border-border/60 bg-card p-4">
+                <h2 className="font-semibold text-foreground">Recent history</h2>
+                <div className="mt-3 space-y-3">
+                  {overview?.history.length ? (
+                    overview.history.map((item) => (
+                      <div className="border-b border-border/50 pb-3 last:border-0 last:pb-0" key={item.id}>
+                        <p className="text-sm font-medium text-foreground">{item.optionText}</p>
+                        <p className="text-xs text-muted-foreground">{item.question}</p>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          {new Date(item.createdAt).toLocaleString()}
+                        </p>
+                      </div>
+                    ))
+                  ) : (
+                    <p className="text-sm text-muted-foreground">No private check-ins yet.</p>
+                  )}
+                </div>
+              </div>
+            </aside>
+          </div>
+        )}
+      </main>
+    </AppShell>
+  )
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md bg-secondary/60 p-3">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="mt-1 truncate font-semibold text-foreground">{value}</p>
+    </div>
+  )
+}

--- a/Frontend/lib/api.ts
+++ b/Frontend/lib/api.ts
@@ -35,6 +35,9 @@ export interface ApiPoll {
   campaignId: number | null
   sponsorName: string | null
   campaignName: string | null
+  isPrivate: boolean
+  isWellness: boolean
+  pollMode: "Public" | "Wellness"
   moderationStatus: "Draft" | "PendingReview" | "Published" | "Rejected" | "Flagged"
   moderationReason: string | null
   moderatedByUserId: number | null
@@ -118,6 +121,31 @@ export interface CreatePollPayload {
   sourceUrl?: string
   thumbnailUrl?: string
   isAIGenerated?: boolean
+  isPrivate?: boolean
+  isWellness?: boolean
+}
+
+export interface ApiWellnessResponse {
+  id: number
+  userId: number
+  pollId: number
+  optionId: number
+  question: string
+  optionText: string
+  note: string | null
+  createdAt: string
+}
+
+export interface ApiWellnessInsight {
+  totalCheckIns: number
+  lastCheckInAt: string | null
+  mostCommonResponse: string | null
+}
+
+export interface ApiWellnessOverview {
+  polls: ApiPoll[]
+  history: ApiWellnessResponse[]
+  insight: ApiWellnessInsight
 }
 
 export interface ApiBusinessAccount {
@@ -376,6 +404,32 @@ export const notificationsApi = {
       method: "PUT",
       body: JSON.stringify({ disabledTypes }),
     }),
+}
+
+export const wellnessApi = {
+  getOverview: () => request<ApiWellnessOverview>("/api/wellness/overview"),
+
+  createResponse: (pollId: number, optionId: number, note?: string) =>
+    request<ApiWellnessResponse>("/api/wellness/responses", {
+      method: "POST",
+      body: JSON.stringify({ pollId, optionId, note }),
+    }),
+
+  deleteResponses: () =>
+    request<void>("/api/wellness/responses", { method: "DELETE" }),
+
+  exportCsv: async () => {
+    const res = await fetch(`${API_BASE_URL}/api/wellness/export.csv`, {
+      headers: authHeaders(),
+    })
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => res.statusText)
+      throw new Error(`API ${res.status}: ${text}`)
+    }
+
+    return res.blob()
+  },
 }
 
 // ── User endpoints ────────────────────────────────────────────────────────────

--- a/Frontend/lib/navigation.ts
+++ b/Frontend/lib/navigation.ts
@@ -1,4 +1,4 @@
-import { Home, BarChart2, PlusCircle, Trophy, Bell, User, BriefcaseBusiness } from "lucide-react"
+import { Home, BarChart2, PlusCircle, Trophy, Bell, User, BriefcaseBusiness, HeartPulse } from "lucide-react"
 
 export const navigationItems = [
   {
@@ -30,6 +30,11 @@ export const navigationItems = [
     label: "Business",
     href: "/business",
     icon: BriefcaseBusiness,
+  },
+  {
+    label: "Wellness",
+    href: "/wellness",
+    icon: HeartPulse,
   },
   {
     label: "Profile",

--- a/Frontend/lib/poll-data.ts
+++ b/Frontend/lib/poll-data.ts
@@ -43,6 +43,8 @@ export interface Poll {
   isSponsored?: boolean
   sponsorName?: string | null
   campaignName?: string | null
+  isPrivate?: boolean
+  isWellness?: boolean
 
   // ── US-12: Full options list for voting (absent on mock polls) ─────────────
   options?: PollOption[]
@@ -97,6 +99,8 @@ export function mapBackendPoll(p: ApiPoll): Poll {
     isSponsored:   p.isSponsored,
     sponsorName:   p.sponsorName,
     campaignName:  p.campaignName,
+    isPrivate:     p.isPrivate,
+    isWellness:    p.isWellness,
     options:      p.options.map((o) => ({
       id:             o.id,
       text:           o.text,


### PR DESCRIPTION
## Summary
- Add private/wellness poll metadata and migration, including seed private wellness check-ins
- Exclude private wellness polls from public feed/search/trending/recent flows and public vote history
- Add separate wellness response storage and owner-scoped wellness APIs for overview, history, CSV export, and delete
- Block public vote casting for private health/wellness polls so sensitive responses use the wellness path
- Add a `/wellness` page with privacy/consent copy, private check-ins, personal insights, history, export, and delete controls

## Verification
- `dotnet build`
- `./node_modules/.bin/tsc --noEmit` from `Frontend`
- `git diff --check`
- `npm run build`
- `npm run lint` could not complete because `eslint` is not installed in `Frontend`

Closes #61