### PR TITLE
Add achievements and badges

### DIFF
--- a/Backend/BackendAPI/Interfaces/IAchievementsRepository.cs
+++ b/Backend/BackendAPI/Interfaces/IAchievementsRepository.cs
@@ -1,0 +1,11 @@
+using BackendAPI.Models;
+
+namespace BackendAPI.Interfaces
+{
+    public interface IAchievementsRepository
+    {
+        Task<IEnumerable<UserBadge>> GetUserBadgesAsync(long userId);
+        Task<Dictionary<long, List<UserBadge>>> GetBadgesForUsersAsync(IEnumerable<long> userIds);
+        Task<AchievementAwardResult> AwardEligibleBadgesAsync(long userId, DateTime utcNow);
+    }
+}

--- a/Backend/BackendAPI/Interfaces/IUsersRepository.cs
+++ b/Backend/BackendAPI/Interfaces/IUsersRepository.cs
@@ -8,6 +8,7 @@ namespace BackendAPI.Interfaces
         Task<User?> GetByIdAsync(long id);
         Task<User?> GetByUsernameAsync(string username);
         Task<long> CreateAsync(CreateUserRequest request);
+        Task IncrementPollsCreatedAsync(long userId);
         Task<VoteRewardResult> ApplyVoteRewardAsync(long userId, int xpToAdd, DateTime utcNow);
         /// <summary>US-22: Returns the user's vote history with poll details.</summary>
         Task<IEnumerable<VoteHistoryItem>> GetVoteHistoryAsync(long userId, int count = 20);

--- a/Backend/BackendAPI/Migrations/US62_Achievements.sql
+++ b/Backend/BackendAPI/Migrations/US62_Achievements.sql
@@ -1,0 +1,62 @@
+IF OBJECT_ID('dbo.AchievementBadges', 'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.AchievementBadges (
+        Id BIGINT IDENTITY(1,1) PRIMARY KEY,
+        Code NVARCHAR(80) NOT NULL,
+        Name NVARCHAR(120) NOT NULL,
+        Description NVARCHAR(300) NOT NULL,
+        Icon NVARCHAR(40) NOT NULL,
+        RuleType NVARCHAR(60) NOT NULL,
+        Threshold INT NOT NULL,
+        RewardXp INT NOT NULL CONSTRAINT DF_AchievementBadges_RewardXp DEFAULT 0,
+        CreatedAt DATETIME2 NOT NULL CONSTRAINT DF_AchievementBadges_CreatedAt DEFAULT GETUTCDATE(),
+        CONSTRAINT UQ_AchievementBadges_Code UNIQUE (Code)
+    );
+END;
+
+IF OBJECT_ID('dbo.UserBadges', 'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.UserBadges (
+        Id BIGINT IDENTITY(1,1) PRIMARY KEY,
+        UserId BIGINT NOT NULL,
+        BadgeId BIGINT NOT NULL,
+        AwardedAt DATETIME2 NOT NULL CONSTRAINT DF_UserBadges_AwardedAt DEFAULT GETUTCDATE(),
+        CONSTRAINT FK_UserBadges_Users FOREIGN KEY (UserId) REFERENCES dbo.Users(Id),
+        CONSTRAINT FK_UserBadges_AchievementBadges FOREIGN KEY (BadgeId) REFERENCES dbo.AchievementBadges(Id),
+        CONSTRAINT UQ_UserBadges_UserBadge UNIQUE (UserId, BadgeId)
+    );
+END;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE name = 'IX_UserBadges_User_AwardedAt'
+      AND object_id = OBJECT_ID('dbo.UserBadges')
+)
+BEGIN
+    CREATE INDEX IX_UserBadges_User_AwardedAt
+    ON dbo.UserBadges (UserId, AwardedAt DESC);
+END;
+
+MERGE dbo.AchievementBadges AS target
+USING (VALUES
+    ('first_vote', 'First Vote', 'Cast your first public vote.', 'Vote', 'VoteCount', 1, 25),
+    ('pulse_10', 'Pulse 10', 'Cast 10 public votes.', 'Zap', 'VoteCount', 10, 50),
+    ('pulse_50', 'Pulse 50', 'Cast 50 public votes.', 'Trophy', 'VoteCount', 50, 150),
+    ('streak_3', 'Three Day Spark', 'Keep a 3 day voting streak.', 'Flame', 'Streak', 3, 50),
+    ('streak_7', 'Weekly Fire', 'Keep a 7 day voting streak.', 'Flame', 'Streak', 7, 125),
+    ('creator_1', 'Poll Starter', 'Create your first poll.', 'PlusCircle', 'PollCreation', 1, 50),
+    ('creator_5', 'Conversation Maker', 'Create 5 polls.', 'MessagesSquare', 'PollCreation', 5, 125),
+    ('challenge_1', 'Challenge Finisher', 'Complete your first challenge.', 'Target', 'ChallengeCompletion', 1, 75)
+) AS source (Code, Name, Description, Icon, RuleType, Threshold, RewardXp)
+ON target.Code = source.Code
+WHEN MATCHED THEN
+    UPDATE SET
+        Name = source.Name,
+        Description = source.Description,
+        Icon = source.Icon,
+        RuleType = source.RuleType,
+        Threshold = source.Threshold,
+        RewardXp = source.RewardXp
+WHEN NOT MATCHED THEN
+    INSERT (Code, Name, Description, Icon, RuleType, Threshold, RewardXp, CreatedAt)
+    VALUES (source.Code, source.Name, source.Description, source.Icon, source.RuleType, source.Threshold, source.RewardXp, GETUTCDATE());

--- a/Backend/BackendAPI/Models/Achievement.cs
+++ b/Backend/BackendAPI/Models/Achievement.cs
@@ -1,0 +1,41 @@
+namespace BackendAPI.Models
+{
+    public class AchievementBadge
+    {
+        public long Id { get; set; }
+        public string Code { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public string Icon { get; set; } = string.Empty;
+        public string RuleType { get; set; } = string.Empty;
+        public int Threshold { get; set; }
+        public int RewardXp { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+
+    public class UserBadge
+    {
+        public long Id { get; set; }
+        public long UserId { get; set; }
+        public long BadgeId { get; set; }
+        public string Code { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public string Icon { get; set; } = string.Empty;
+        public DateTime AwardedAt { get; set; }
+    }
+
+    public class AchievementAwardResult
+    {
+        public IEnumerable<UserBadge> AwardedBadges { get; set; } = Enumerable.Empty<UserBadge>();
+        public int BonusXpAwarded { get; set; }
+    }
+
+    public static class AchievementRuleType
+    {
+        public const string VoteCount = "VoteCount";
+        public const string Streak = "Streak";
+        public const string PollCreation = "PollCreation";
+        public const string ChallengeCompletion = "ChallengeCompletion";
+    }
+}

--- a/Backend/BackendAPI/Models/Auth.cs
+++ b/Backend/BackendAPI/Models/Auth.cs
@@ -45,5 +45,7 @@ namespace BackendAPI.Models
         public int PollsCreated { get; set; }
         public DateTime? LastVoteDate { get; set; }
         public DateTime CreatedAt { get; set; }
+        public int Level => Xp / 1000 + 1;
+        public List<UserBadge> Badges { get; set; } = new();
     }
 }

--- a/Backend/BackendAPI/Models/User.cs
+++ b/Backend/BackendAPI/Models/User.cs
@@ -11,6 +11,8 @@ namespace BackendAPI.Models
         public int PollsCreated { get; set; }
         public DateTime? LastVoteDate { get; set; }
         public DateTime CreatedAt { get; set; }
+        public int Level => Xp / 1000 + 1;
+        public List<UserBadge> Badges { get; set; } = new();
     }
 
     public class CreateUserRequest
@@ -38,6 +40,8 @@ namespace BackendAPI.Models
         public int XpAwarded { get; set; }
         public bool StreakAdvanced { get; set; }
         public DateTime? LastVoteDate { get; set; }
+        public int Level => Xp / 1000 + 1;
+        public IEnumerable<UserBadge> AwardedBadges { get; set; } = Enumerable.Empty<UserBadge>();
     }
 
     public class UserCategoryPreference

--- a/Backend/BackendAPI/Program.cs
+++ b/Backend/BackendAPI/Program.cs
@@ -63,6 +63,7 @@ builder.Services.AddScoped<ITrendingTopicRepository, TrendingTopicRepository>();
 builder.Services.AddScoped<IChallengesRepository,    ChallengesRepository>();
 builder.Services.AddScoped<IBusinessRepository,      BusinessRepository>();
 builder.Services.AddScoped<IWellnessRepository,      WellnessRepository>();
+builder.Services.AddScoped<IAchievementsRepository,  AchievementsRepository>();
 
 // ── Ingestion Services (US-03, US-04, US-05) ──────────────────────────────
 builder.Services.AddHttpClient();

--- a/Backend/BackendAPI/Repository/AchievementsRepository.cs
+++ b/Backend/BackendAPI/Repository/AchievementsRepository.cs
@@ -1,0 +1,154 @@
+using BackendAPI.Data;
+using BackendAPI.Interfaces;
+using BackendAPI.Models;
+using Dapper;
+
+namespace BackendAPI.Repository
+{
+    public class AchievementsRepository : IAchievementsRepository
+    {
+        private readonly DapperContext _context;
+
+        public AchievementsRepository(DapperContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<IEnumerable<UserBadge>> GetUserBadgesAsync(long userId)
+        {
+            using var conn = _context.CreateConnection();
+            return await conn.QueryAsync<UserBadge>(
+                BadgeSelectSql + " WHERE ub.UserId = @UserId ORDER BY ub.AwardedAt DESC",
+                new { UserId = userId });
+        }
+
+        public async Task<Dictionary<long, List<UserBadge>>> GetBadgesForUsersAsync(IEnumerable<long> userIds)
+        {
+            var ids = userIds.Distinct().ToArray();
+            if (ids.Length == 0) return new Dictionary<long, List<UserBadge>>();
+
+            using var conn = _context.CreateConnection();
+            var badges = await conn.QueryAsync<UserBadge>(
+                BadgeSelectSql + " WHERE ub.UserId IN @UserIds ORDER BY ub.AwardedAt DESC",
+                new { UserIds = ids });
+
+            return badges
+                .GroupBy(badge => badge.UserId)
+                .ToDictionary(group => group.Key, group => group.ToList());
+        }
+
+        public async Task<AchievementAwardResult> AwardEligibleBadgesAsync(long userId, DateTime utcNow)
+        {
+            using var conn = _context.CreateConnection();
+            conn.Open();
+            using var transaction = conn.BeginTransaction();
+
+            try
+            {
+                var user = await conn.QuerySingleAsync<User>(
+                    "SELECT Id, Xp, Streak, TotalVotes, PollsCreated FROM Users WHERE Id = @UserId",
+                    new { UserId = userId },
+                    transaction);
+
+                var completedChallenges = await conn.ExecuteScalarAsync<int>(
+                    @"SELECT COUNT(1)
+                      FROM UserChallengeProgress
+                      WHERE UserId = @UserId AND IsCompleted = 1",
+                    new { UserId = userId },
+                    transaction);
+
+                var eligible = (await conn.QueryAsync<AchievementBadge>(
+                    @"SELECT *
+                      FROM AchievementBadges
+                      WHERE (RuleType = @VoteCountRule AND Threshold <= @TotalVotes)
+                         OR (RuleType = @StreakRule AND Threshold <= @Streak)
+                         OR (RuleType = @PollCreationRule AND Threshold <= @PollsCreated)
+                         OR (RuleType = @ChallengeCompletionRule AND Threshold <= @CompletedChallenges)",
+                    new
+                    {
+                        VoteCountRule = AchievementRuleType.VoteCount,
+                        StreakRule = AchievementRuleType.Streak,
+                        PollCreationRule = AchievementRuleType.PollCreation,
+                        ChallengeCompletionRule = AchievementRuleType.ChallengeCompletion,
+                        user.TotalVotes,
+                        user.Streak,
+                        user.PollsCreated,
+                        CompletedChallenges = completedChallenges
+                    },
+                    transaction)).ToList();
+
+                var awarded = new List<UserBadge>();
+                var bonusXp = 0;
+
+                foreach (var badge in eligible)
+                {
+                    var inserted = await conn.ExecuteScalarAsync<long?>(
+                        @"IF NOT EXISTS (
+                              SELECT 1 FROM UserBadges
+                              WHERE UserId = @UserId AND BadgeId = @BadgeId
+                          )
+                          BEGIN
+                              INSERT INTO UserBadges (UserId, BadgeId, AwardedAt)
+                              VALUES (@UserId, @BadgeId, @AwardedAt);
+                              SELECT CAST(SCOPE_IDENTITY() AS BIGINT);
+                          END
+                          ELSE
+                          BEGIN
+                              SELECT CAST(NULL AS BIGINT);
+                          END",
+                        new { UserId = userId, BadgeId = badge.Id, AwardedAt = utcNow },
+                        transaction);
+
+                    if (inserted == null) continue;
+
+                    bonusXp += badge.RewardXp;
+                    awarded.Add(new UserBadge
+                    {
+                        Id = inserted.Value,
+                        UserId = userId,
+                        BadgeId = badge.Id,
+                        Code = badge.Code,
+                        Name = badge.Name,
+                        Description = badge.Description,
+                        Icon = badge.Icon,
+                        AwardedAt = utcNow
+                    });
+                }
+
+                if (bonusXp > 0)
+                {
+                    await conn.ExecuteAsync(
+                        "UPDATE Users SET Xp = Xp + @BonusXp WHERE Id = @UserId",
+                        new { UserId = userId, BonusXp = bonusXp },
+                        transaction);
+                }
+
+                transaction.Commit();
+
+                return new AchievementAwardResult
+                {
+                    AwardedBadges = awarded,
+                    BonusXpAwarded = bonusXp
+                };
+            }
+            catch
+            {
+                transaction.Rollback();
+                throw;
+            }
+        }
+
+        private const string BadgeSelectSql =
+            @"SELECT
+                  ub.Id,
+                  ub.UserId,
+                  ub.BadgeId,
+                  b.Code,
+                  b.Name,
+                  b.Description,
+                  b.Icon,
+                  ub.AwardedAt
+              FROM UserBadges ub
+              JOIN AchievementBadges b ON b.Id = ub.BadgeId";
+    }
+}

--- a/Backend/BackendAPI/Repository/AuthRepository.cs
+++ b/Backend/BackendAPI/Repository/AuthRepository.cs
@@ -13,11 +13,16 @@ namespace BackendAPI.Repository
     {
         private readonly DapperContext _context;
         private readonly IConfiguration _config;
+        private readonly IAchievementsRepository _achievementsRepo;
 
-        public AuthRepository(DapperContext context, IConfiguration config)
+        public AuthRepository(
+            DapperContext context,
+            IConfiguration config,
+            IAchievementsRepository achievementsRepo)
         {
             _context = context;
             _config = config;
+            _achievementsRepo = achievementsRepo;
         }
 
         // ── Register ─────────────────────────────────────────────────────────
@@ -124,12 +129,17 @@ namespace BackendAPI.Repository
         private async Task<UserResponse?> GetUserResponseAsync(long id)
         {
             using var conn = _context.CreateConnection();
-            return await conn.QueryFirstOrDefaultAsync<UserResponse>(
+            var user = await conn.QueryFirstOrDefaultAsync<UserResponse>(
                 @"SELECT Id, Username, DisplayName, Email, AvatarUrl, AuthProvider,
                          Xp, Streak, TotalVotes, PollsCreated, LastVoteDate, CreatedAt
                   FROM Users WHERE Id = @Id",
                 new { Id = id }
             );
+
+            if (user != null)
+                user.Badges = (await _achievementsRepo.GetUserBadgesAsync(id)).ToList();
+
+            return user;
         }
 
         private string GenerateToken(UserResponse user)

--- a/Backend/BackendAPI/Repository/ChallengesRepository.cs
+++ b/Backend/BackendAPI/Repository/ChallengesRepository.cs
@@ -8,10 +8,12 @@ namespace BackendAPI.Repository
     public class ChallengesRepository : IChallengesRepository
     {
         private readonly DapperContext _context;
+        private readonly IAchievementsRepository _achievementsRepo;
 
-        public ChallengesRepository(DapperContext context)
+        public ChallengesRepository(DapperContext context, IAchievementsRepository achievementsRepo)
         {
             _context = context;
+            _achievementsRepo = achievementsRepo;
         }
 
         public async Task EnsureDailyChallengeAsync(DateTime utcNow)
@@ -178,6 +180,8 @@ namespace BackendAPI.Repository
                 transaction.Rollback();
                 throw;
             }
+
+            await _achievementsRepo.AwardEligibleBadgesAsync(userId, utcNow);
 
             return await GetActiveForUserAsync(userId, utcNow);
         }

--- a/Backend/BackendAPI/Repository/PollsRepository.cs
+++ b/Backend/BackendAPI/Repository/PollsRepository.cs
@@ -8,10 +8,12 @@ namespace BackendAPI.Repository
     public class PollsRepository : IPollsRepository
     {
         private readonly DapperContext _context;
+        private readonly IUsersRepository _usersRepo;
 
-        public PollsRepository(DapperContext context)
+        public PollsRepository(DapperContext context, IUsersRepository usersRepo)
         {
             _context = context;
+            _usersRepo = usersRepo;
         }
 
         // ── Helpers ───────────────────────────────────────────────────────────
@@ -428,16 +430,11 @@ namespace BackendAPI.Repository
                     );
                 }
 
+                transaction.Commit();
                 if (createdByUserId != null)
                 {
-                    await conn.ExecuteAsync(
-                        "UPDATE Users SET PollsCreated = PollsCreated + 1 WHERE Id = @UserId",
-                        new { UserId = createdByUserId },
-                        transaction
-                    );
+                    await _usersRepo.IncrementPollsCreatedAsync(createdByUserId.Value);
                 }
-
-                transaction.Commit();
                 return pollId;
             }
             catch

--- a/Backend/BackendAPI/Repository/UsersRepository.cs
+++ b/Backend/BackendAPI/Repository/UsersRepository.cs
@@ -9,28 +9,44 @@ namespace BackendAPI.Repository
     public class UsersRepository : IUsersRepository
     {
         private readonly DapperContext _context;
+        private readonly IAchievementsRepository _achievementsRepo;
 
-        public UsersRepository(DapperContext context)
+        public UsersRepository(DapperContext context, IAchievementsRepository achievementsRepo)
         {
             _context = context;
+            _achievementsRepo = achievementsRepo;
         }
 
         public async Task<IEnumerable<User>> GetLeaderboardAsync(int count = 20)
         {
             using var conn = _context.CreateConnection();
-            return await conn.QueryAsync<User>(
+            var users = (await conn.QueryAsync<User>(
                 "SELECT TOP (@Count) * FROM Users ORDER BY Xp DESC",
                 new { Count = count }
-            );
+            )).ToList();
+
+            var badgesByUser = await _achievementsRepo.GetBadgesForUsersAsync(users.Select(user => user.Id));
+            foreach (var user in users)
+            {
+                if (badgesByUser.TryGetValue(user.Id, out var badges))
+                    user.Badges = badges;
+            }
+
+            return users;
         }
 
         public async Task<User?> GetByIdAsync(long id)
         {
             using var conn = _context.CreateConnection();
-            return await conn.QueryFirstOrDefaultAsync<User>(
+            var user = await conn.QueryFirstOrDefaultAsync<User>(
                 "SELECT * FROM Users WHERE Id = @Id",
                 new { Id = id }
             );
+
+            if (user != null)
+                user.Badges = (await _achievementsRepo.GetUserBadgesAsync(id)).ToList();
+
+            return user;
         }
 
         public async Task<User?> GetByUsernameAsync(string username)
@@ -51,6 +67,16 @@ namespace BackendAPI.Repository
                   SELECT SCOPE_IDENTITY();",
                 new { request.Username, request.DisplayName }
             );
+        }
+
+        public async Task IncrementPollsCreatedAsync(long userId)
+        {
+            using var conn = _context.CreateConnection();
+            await conn.ExecuteAsync(
+                "UPDATE Users SET PollsCreated = PollsCreated + 1 WHERE Id = @UserId",
+                new { UserId = userId });
+
+            await _achievementsRepo.AwardEligibleBadgesAsync(userId, DateTime.UtcNow);
         }
 
         public async Task<VoteRewardResult> ApplyVoteRewardAsync(long userId, int xpToAdd, DateTime utcNow)
@@ -97,6 +123,15 @@ namespace BackendAPI.Repository
             );
 
             transaction.Commit();
+
+            var awards = await _achievementsRepo.AwardEligibleBadgesAsync(userId, utcNow);
+            updated.AwardedBadges = awards.AwardedBadges;
+            if (awards.BonusXpAwarded > 0)
+            {
+                updated.Xp += awards.BonusXpAwarded;
+                updated.XpAwarded += awards.BonusXpAwarded;
+            }
+
             return updated;
         }
 

--- a/Frontend/app/leaderboard/page.tsx
+++ b/Frontend/app/leaderboard/page.tsx
@@ -134,6 +134,18 @@ export default function LeaderboardPage() {
                       )}
                     </div>
                     <p className="text-sm text-muted-foreground">@{user.username}</p>
+                    {user.badges?.length > 0 && (
+                      <div className="mt-1 flex flex-wrap gap-1">
+                        {user.badges.slice(0, 2).map((badge) => (
+                          <span
+                            className="rounded-full bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold text-amber-600 dark:text-amber-400"
+                            key={badge.id}
+                          >
+                            {badge.name}
+                          </span>
+                        ))}
+                      </div>
+                    )}
                   </div>
 
                   <div className="text-right">
@@ -142,7 +154,7 @@ export default function LeaderboardPage() {
                       {user.xp.toLocaleString()}
                     </div>
                     <p className="text-xs text-muted-foreground">
-                      Level {levelFromXp(user.xp)} · {user.totalVotes.toLocaleString()} votes
+                      Level {user.level ?? levelFromXp(user.xp)} - {user.totalVotes.toLocaleString()} votes
                     </p>
                   </div>
                 </motion.div>

--- a/Frontend/app/profile/page.tsx
+++ b/Frontend/app/profile/page.tsx
@@ -14,6 +14,7 @@ import {
   Clock,
   LogOut,
   CheckCircle2,
+  Award,
 } from "lucide-react"
 import { AppShell } from "@/components/app-shell"
 import { CategoryBadge } from "@/components/category-badge"
@@ -96,6 +97,7 @@ export default function ProfilePage() {
   // Use fresh API data when available, fall back to cached auth user
   const displayUser = profile ?? authUser
   const { level, progress, nextXp } = xpLevel(displayUser.xp ?? 0)
+  const badges = displayUser.badges ?? []
 
   const stats = [
     { icon: BarChart3, label: "Polls Created", value: String(displayUser.pollsCreated ?? 0), color: "text-primary"     },
@@ -166,7 +168,7 @@ export default function ProfilePage() {
                     <span className="text-muted-foreground">Level {level}</span>
                     <span className="flex items-center gap-1 font-medium text-primary">
                       <Zap className="h-3.5 w-3.5" />
-                      {authUser.xp ?? 0} / {nextXp} XP
+                      {displayUser.xp ?? 0} / {nextXp} XP
                     </span>
                   </div>
                   <div className="mt-1 h-2 overflow-hidden rounded-full bg-background">
@@ -207,6 +209,42 @@ export default function ProfilePage() {
         </motion.div>
 
         {/* Vote History */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.18 }}
+          className="mb-6"
+        >
+          <h2 className="mb-3 text-lg font-semibold text-foreground">Badges</h2>
+          {badges.length === 0 ? (
+            <div className="rounded-2xl bg-card p-6 text-center ring-1 ring-border/50">
+              <Award className="mx-auto h-8 w-8 text-muted-foreground" />
+              <p className="mt-2 text-sm text-muted-foreground">
+                Keep voting, creating, and completing challenges to earn badges.
+              </p>
+            </div>
+          ) : (
+            <div className="grid gap-3 sm:grid-cols-2">
+              {badges.slice(0, 6).map((badge) => (
+                <div
+                  className="rounded-2xl bg-card p-4 ring-1 ring-border/50"
+                  key={badge.id}
+                >
+                  <div className="flex items-center gap-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                      <Award className="h-5 w-5" />
+                    </div>
+                    <div className="min-w-0">
+                      <p className="truncate font-semibold text-foreground">{badge.name}</p>
+                      <p className="line-clamp-2 text-xs text-muted-foreground">{badge.description}</p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </motion.div>
+
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}

--- a/Frontend/lib/api.ts
+++ b/Frontend/lib/api.ts
@@ -61,11 +61,13 @@ export interface CastVoteRequest {
 
 export interface ApiVoteReward {
   xp: number
+  level: number
   streak: number
   totalVotes: number
   xpAwarded: number
   streakAdvanced: boolean
   lastVoteDate: string | null
+  awardedBadges: ApiUserBadge[]
 }
 
 export interface ApiCastVoteResponse {
@@ -451,6 +453,19 @@ export interface ApiUser {
   pollsCreated: number
   lastVoteDate?: string | null
   createdAt: string
+  level: number
+  badges: ApiUserBadge[]
+}
+
+export interface ApiUserBadge {
+  id: number
+  userId: number
+  badgeId: number
+  code: string
+  name: string
+  description: string
+  icon: string
+  awardedAt: string
 }
 
 export interface ApiVoteHistoryItem {

--- a/Frontend/lib/auth.ts
+++ b/Frontend/lib/auth.ts
@@ -16,6 +16,17 @@ export interface AuthUser {
   pollsCreated: number
   lastVoteDate?: string | null
   createdAt: string
+  level?: number
+  badges?: Array<{
+    id: number
+    userId: number
+    badgeId: number
+    code: string
+    name: string
+    description: string
+    icon: string
+    awardedAt: string
+  }>
 }
 
 export interface AuthResponse {


### PR DESCRIPTION
## Summary
- Add achievement badge and awarded user badge schema with seeded MVP badge rules
- Add idempotent backend awarding for vote count, streak, poll creation, and challenge completion milestones
- Include consistent computed levels and awarded badges on profile/auth and leaderboard user responses
- Award bonus XP from newly earned badges without duplicating rewards
- Display earned badges on profile and compact badge chips on leaderboard rows

## Verification
- `dotnet build`
- `./node_modules/.bin/tsc --noEmit` from `Frontend`
- `git diff --check`
- `npm run build`
- `npm run lint` could not complete because `eslint` is not installed in `Frontend`

Closes #62