### PR TITLE
Add Expo push notifications for retention

### DIFF
--- a/Backend/BackendAPI/Controllers/NotificationsController.cs
+++ b/Backend/BackendAPI/Controllers/NotificationsController.cs
@@ -86,5 +86,31 @@ namespace BackendAPI.Controllers
                 request.DisabledTypes);
             return Ok(preferences);
         }
+
+        // POST /api/notifications/device-tokens
+        [HttpPost("device-tokens")]
+        public async Task<IActionResult> RegisterDeviceToken([FromBody] RegisterPushTokenRequest request)
+        {
+            var userId = CurrentUserId();
+            if (userId == null) return Unauthorized(new { message = "Invalid token." });
+            if (string.IsNullOrWhiteSpace(request.Token))
+                return BadRequest(new { message = "Push token is required." });
+
+            await _notificationsRepo.RegisterDeviceTokenAsync(userId.Value, request);
+            return Ok(new { success = true });
+        }
+
+        // DELETE /api/notifications/device-tokens?token=ExponentPushToken...
+        [HttpDelete("device-tokens")]
+        public async Task<IActionResult> DisableDeviceToken([FromQuery] string? token)
+        {
+            var userId = CurrentUserId();
+            if (userId == null) return Unauthorized(new { message = "Invalid token." });
+            if (string.IsNullOrWhiteSpace(token))
+                return BadRequest(new { message = "Push token is required." });
+
+            await _notificationsRepo.DisableDeviceTokenAsync(userId.Value, token);
+            return Ok(new { success = true });
+        }
     }
 }

--- a/Backend/BackendAPI/Interfaces/INotificationsRepository.cs
+++ b/Backend/BackendAPI/Interfaces/INotificationsRepository.cs
@@ -13,6 +13,15 @@ namespace BackendAPI.Interfaces
         Task<IEnumerable<NotificationPreference>> ReplacePreferencesAsync(
             long userId,
             IEnumerable<NotificationType> disabledTypes);
+        Task RegisterDeviceTokenAsync(long userId, RegisterPushTokenRequest request);
+        Task DisableDeviceTokenAsync(long userId, string token);
+        Task<IEnumerable<PushNotificationCandidate>> GetPendingPushNotificationsAsync(int count = 100);
+        Task MarkPushAttemptAsync(
+            long notificationId,
+            long deviceTokenId,
+            bool success,
+            string? providerMessageId,
+            string? errorMessage);
         Task<int> CreateDailyChallengeNotificationsAsync(DateTime utcNow);
         Task<int> CreateStreakReminderNotificationsAsync(DateTime utcNow);
         Task<int> CreateTrendingPollNotificationsAsync(DateTime utcNow);

--- a/Backend/BackendAPI/Interfaces/IPushNotificationService.cs
+++ b/Backend/BackendAPI/Interfaces/IPushNotificationService.cs
@@ -1,0 +1,7 @@
+namespace BackendAPI.Interfaces
+{
+    public interface IPushNotificationService
+    {
+        Task<int> SendPendingAsync(int count = 100);
+    }
+}

--- a/Backend/BackendAPI/Jobs/RetentionNotificationJob.cs
+++ b/Backend/BackendAPI/Jobs/RetentionNotificationJob.cs
@@ -6,15 +6,18 @@ namespace BackendAPI.Jobs
     {
         private readonly IChallengesRepository _challengesRepo;
         private readonly INotificationsRepository _notificationsRepo;
+        private readonly IPushNotificationService _pushNotificationService;
         private readonly ILogger<RetentionNotificationJob> _logger;
 
         public RetentionNotificationJob(
             IChallengesRepository challengesRepo,
             INotificationsRepository notificationsRepo,
+            IPushNotificationService pushNotificationService,
             ILogger<RetentionNotificationJob> logger)
         {
             _challengesRepo = challengesRepo;
             _notificationsRepo = notificationsRepo;
+            _pushNotificationService = pushNotificationService;
             _logger = logger;
         }
 
@@ -27,13 +30,15 @@ namespace BackendAPI.Jobs
             var streakCount = await _notificationsRepo.CreateStreakReminderNotificationsAsync(utcNow);
             var trendingCount = await _notificationsRepo.CreateTrendingPollNotificationsAsync(utcNow);
             var expiringCount = await _notificationsRepo.CreateExpiringPollNotificationsAsync(utcNow);
+            var pushCount = await _pushNotificationService.SendPendingAsync();
 
             _logger.LogInformation(
-                "[RetentionNotificationJob] Created notifications. challenge={ChallengeCount}, streak={StreakCount}, trending={TrendingCount}, expiring={ExpiringCount}",
+                "[RetentionNotificationJob] Created notifications. challenge={ChallengeCount}, streak={StreakCount}, trending={TrendingCount}, expiring={ExpiringCount}, push={PushCount}",
                 challengeCount,
                 streakCount,
                 trendingCount,
-                expiringCount);
+                expiringCount,
+                pushCount);
         }
     }
 }

--- a/Backend/BackendAPI/Migrations/US97_Expo_Push_Notifications.sql
+++ b/Backend/BackendAPI/Migrations/US97_Expo_Push_Notifications.sql
@@ -1,0 +1,42 @@
+IF OBJECT_ID('dbo.MobileDeviceTokens', 'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.MobileDeviceTokens (
+        Id BIGINT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+        UserId BIGINT NOT NULL,
+        Token NVARCHAR(256) NOT NULL,
+        Platform NVARCHAR(32) NOT NULL CONSTRAINT DF_MobileDeviceTokens_Platform DEFAULT 'android',
+        DeviceId NVARCHAR(128) NULL,
+        IsActive BIT NOT NULL CONSTRAINT DF_MobileDeviceTokens_IsActive DEFAULT 1,
+        CreatedAt DATETIME2 NOT NULL CONSTRAINT DF_MobileDeviceTokens_CreatedAt DEFAULT GETUTCDATE(),
+        UpdatedAt DATETIME2 NOT NULL CONSTRAINT DF_MobileDeviceTokens_UpdatedAt DEFAULT GETUTCDATE(),
+        LastSeenAt DATETIME2 NOT NULL CONSTRAINT DF_MobileDeviceTokens_LastSeenAt DEFAULT GETUTCDATE(),
+        CONSTRAINT FK_MobileDeviceTokens_Users FOREIGN KEY (UserId) REFERENCES dbo.Users(Id),
+        CONSTRAINT UQ_MobileDeviceTokens_Token UNIQUE (Token)
+    );
+END;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE name = 'IX_MobileDeviceTokens_UserActive'
+      AND object_id = OBJECT_ID('dbo.MobileDeviceTokens')
+)
+BEGIN
+    CREATE INDEX IX_MobileDeviceTokens_UserActive
+    ON dbo.MobileDeviceTokens (UserId, IsActive, LastSeenAt DESC);
+END;
+
+IF OBJECT_ID('dbo.NotificationPushDeliveries', 'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.NotificationPushDeliveries (
+        Id BIGINT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+        NotificationId BIGINT NOT NULL,
+        DeviceTokenId BIGINT NOT NULL,
+        Status NVARCHAR(32) NOT NULL,
+        ProviderMessageId NVARCHAR(256) NULL,
+        ErrorMessage NVARCHAR(1000) NULL,
+        AttemptedAt DATETIME2 NOT NULL CONSTRAINT DF_NotificationPushDeliveries_AttemptedAt DEFAULT GETUTCDATE(),
+        CONSTRAINT FK_NotificationPushDeliveries_Notifications FOREIGN KEY (NotificationId) REFERENCES dbo.Notifications(Id),
+        CONSTRAINT FK_NotificationPushDeliveries_MobileDeviceTokens FOREIGN KEY (DeviceTokenId) REFERENCES dbo.MobileDeviceTokens(Id),
+        CONSTRAINT UQ_NotificationPushDeliveries_NotificationDevice UNIQUE (NotificationId, DeviceTokenId)
+    );
+END;

--- a/Backend/BackendAPI/Models/Notification.cs
+++ b/Backend/BackendAPI/Models/Notification.cs
@@ -44,4 +44,22 @@ namespace BackendAPI.Models
     {
         public List<NotificationType> DisabledTypes { get; set; } = new();
     }
+
+    public class RegisterPushTokenRequest
+    {
+        public string Token { get; set; } = string.Empty;
+        public string Platform { get; set; } = "android";
+        public string? DeviceId { get; set; }
+    }
+
+    public class PushNotificationCandidate
+    {
+        public long NotificationId { get; set; }
+        public long DeviceTokenId { get; set; }
+        public string Token { get; set; } = string.Empty;
+        public string Title { get; set; } = string.Empty;
+        public string Body { get; set; } = string.Empty;
+        public long? PollId { get; set; }
+        public NotificationType Type { get; set; }
+    }
 }

--- a/Backend/BackendAPI/Program.cs
+++ b/Backend/BackendAPI/Program.cs
@@ -67,6 +67,7 @@ builder.Services.AddScoped<IAchievementsRepository,  AchievementsRepository>();
 
 // ── Ingestion Services (US-03, US-04, US-05) ──────────────────────────────
 builder.Services.AddHttpClient();
+builder.Services.AddHttpClient<IPushNotificationService, ExpoPushNotificationService>();
 builder.Services.AddScoped<IRssIngestionService,     RssIngestionService>();
 builder.Services.AddScoped<IYouTubeIngestionService, YouTubeIngestionService>();
 builder.Services.AddScoped<IGNewsIngestionService,   GNewsIngestionService>();

--- a/Backend/BackendAPI/Repository/NotificationsRepository.cs
+++ b/Backend/BackendAPI/Repository/NotificationsRepository.cs
@@ -138,6 +138,103 @@ namespace BackendAPI.Repository
             return await QueryPreferencesAsync(userId);
         }
 
+        public async Task RegisterDeviceTokenAsync(long userId, RegisterPushTokenRequest request)
+        {
+            using var conn = _context.CreateConnection();
+            await conn.ExecuteAsync(
+                @"IF EXISTS (SELECT 1 FROM MobileDeviceTokens WHERE Token = @Token)
+                  BEGIN
+                      UPDATE MobileDeviceTokens
+                         SET UserId = @UserId,
+                             Platform = @Platform,
+                             DeviceId = @DeviceId,
+                             IsActive = 1,
+                             UpdatedAt = GETUTCDATE(),
+                             LastSeenAt = GETUTCDATE()
+                       WHERE Token = @Token;
+                  END
+                  ELSE
+                  BEGIN
+                      INSERT INTO MobileDeviceTokens (UserId, Token, Platform, DeviceId, IsActive, CreatedAt, UpdatedAt, LastSeenAt)
+                      VALUES (@UserId, @Token, @Platform, @DeviceId, 1, GETUTCDATE(), GETUTCDATE(), GETUTCDATE());
+                  END",
+                new
+                {
+                    UserId = userId,
+                    Token = request.Token.Trim(),
+                    Platform = string.IsNullOrWhiteSpace(request.Platform) ? "android" : request.Platform.Trim().ToLowerInvariant(),
+                    DeviceId = string.IsNullOrWhiteSpace(request.DeviceId) ? null : request.DeviceId.Trim()
+                });
+        }
+
+        public async Task DisableDeviceTokenAsync(long userId, string token)
+        {
+            using var conn = _context.CreateConnection();
+            await conn.ExecuteAsync(
+                @"UPDATE MobileDeviceTokens
+                     SET IsActive = 0,
+                         UpdatedAt = GETUTCDATE()
+                   WHERE UserId = @UserId AND Token = @Token",
+                new { UserId = userId, Token = token.Trim() });
+        }
+
+        public async Task<IEnumerable<PushNotificationCandidate>> GetPendingPushNotificationsAsync(int count = 100)
+        {
+            using var conn = _context.CreateConnection();
+            return await conn.QueryAsync<PushNotificationCandidate>(
+                @"SELECT TOP (@Count)
+                         n.Id AS NotificationId,
+                         token.Id AS DeviceTokenId,
+                         token.Token,
+                         n.Title,
+                         n.Body,
+                         n.PollId,
+                         n.Type
+                    FROM Notifications n
+                    JOIN MobileDeviceTokens token
+                      ON token.UserId = n.UserId
+                     AND token.IsActive = 1
+                    WHERE n.CreatedAt >= DATEADD(day, -2, GETUTCDATE())
+                      AND NOT EXISTS (
+                          SELECT 1
+                          FROM NotificationPushDeliveries delivery
+                          WHERE delivery.NotificationId = n.Id
+                            AND delivery.DeviceTokenId = token.Id
+                      )
+                    ORDER BY n.CreatedAt ASC",
+                new { Count = Math.Clamp(count, 1, 500) });
+        }
+
+        public async Task MarkPushAttemptAsync(
+            long notificationId,
+            long deviceTokenId,
+            bool success,
+            string? providerMessageId,
+            string? errorMessage)
+        {
+            using var conn = _context.CreateConnection();
+            await conn.ExecuteAsync(
+                @"IF NOT EXISTS (
+                      SELECT 1
+                      FROM NotificationPushDeliveries
+                      WHERE NotificationId = @NotificationId AND DeviceTokenId = @DeviceTokenId
+                  )
+                  BEGIN
+                      INSERT INTO NotificationPushDeliveries (
+                          NotificationId, DeviceTokenId, Status, ProviderMessageId, ErrorMessage, AttemptedAt)
+                      VALUES (
+                          @NotificationId, @DeviceTokenId, @Status, @ProviderMessageId, @ErrorMessage, GETUTCDATE());
+                  END",
+                new
+                {
+                    NotificationId = notificationId,
+                    DeviceTokenId = deviceTokenId,
+                    Status = success ? "Sent" : "Failed",
+                    ProviderMessageId = providerMessageId,
+                    ErrorMessage = errorMessage
+                });
+        }
+
         public async Task<int> CreateDailyChallengeNotificationsAsync(DateTime utcNow)
         {
             using var conn = _context.CreateConnection();

--- a/Backend/BackendAPI/Services/ExpoPushNotificationService.cs
+++ b/Backend/BackendAPI/Services/ExpoPushNotificationService.cs
@@ -1,0 +1,138 @@
+using BackendAPI.Interfaces;
+using BackendAPI.Models;
+using System.Text;
+using System.Text.Json;
+
+namespace BackendAPI.Services
+{
+    public class ExpoPushNotificationService : IPushNotificationService
+    {
+        private const string ExpoPushEndpoint = "https://exp.host/--/api/v2/push/send";
+
+        private readonly HttpClient _httpClient;
+        private readonly INotificationsRepository _notificationsRepo;
+        private readonly ILogger<ExpoPushNotificationService> _logger;
+
+        public ExpoPushNotificationService(
+            HttpClient httpClient,
+            INotificationsRepository notificationsRepo,
+            ILogger<ExpoPushNotificationService> logger)
+        {
+            _httpClient = httpClient;
+            _notificationsRepo = notificationsRepo;
+            _logger = logger;
+        }
+
+        public async Task<int> SendPendingAsync(int count = 100)
+        {
+            var candidates = (await _notificationsRepo.GetPendingPushNotificationsAsync(count)).ToList();
+            var sent = 0;
+
+            foreach (var candidate in candidates)
+            {
+                var payload = new
+                {
+                    to = candidate.Token,
+                    title = candidate.Title,
+                    body = candidate.Body,
+                    sound = "default",
+                    data = new
+                    {
+                        notificationId = candidate.NotificationId,
+                        type = candidate.Type.ToString(),
+                        pollId = candidate.PollId,
+                        path = candidate.PollId.HasValue ? $"/polls/{candidate.PollId.Value}" : "/notifications"
+                    }
+                };
+
+                try
+                {
+                    using var content = new StringContent(
+                        JsonSerializer.Serialize(payload),
+                        Encoding.UTF8,
+                        "application/json");
+                    using var response = await _httpClient.PostAsync(ExpoPushEndpoint, content);
+                    var responseText = await response.Content.ReadAsStringAsync();
+
+                    var success = response.IsSuccessStatusCode
+                        && !responseText.Contains("\"status\":\"error\"", StringComparison.OrdinalIgnoreCase);
+
+                    await _notificationsRepo.MarkPushAttemptAsync(
+                        candidate.NotificationId,
+                        candidate.DeviceTokenId,
+                        success,
+                        TryReadExpoId(responseText),
+                        success ? null : responseText[..Math.Min(1000, responseText.Length)]);
+
+                    if (success)
+                    {
+                        sent++;
+                    }
+                    else
+                    {
+                        _logger.LogWarning(
+                            "[ExpoPush] Failed to send notification {NotificationId} to device token {DeviceTokenId}. Response={Response}",
+                            candidate.NotificationId,
+                            candidate.DeviceTokenId,
+                            responseText[..Math.Min(400, responseText.Length)]);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    await _notificationsRepo.MarkPushAttemptAsync(
+                        candidate.NotificationId,
+                        candidate.DeviceTokenId,
+                        false,
+                        null,
+                        ex.Message);
+
+                    _logger.LogError(
+                        ex,
+                        "[ExpoPush] Exception sending notification {NotificationId} to device token {DeviceTokenId}",
+                        candidate.NotificationId,
+                        candidate.DeviceTokenId);
+                }
+            }
+
+            if (candidates.Count > 0)
+            {
+                _logger.LogInformation(
+                    "[ExpoPush] Sent {SentCount}/{CandidateCount} pending push notifications",
+                    sent,
+                    candidates.Count);
+            }
+
+            return sent;
+        }
+
+        private static string? TryReadExpoId(string responseText)
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(responseText);
+                var root = doc.RootElement;
+                if (root.TryGetProperty("data", out var data))
+                {
+                    if (data.ValueKind == JsonValueKind.Object
+                        && data.TryGetProperty("id", out var id))
+                    {
+                        return id.GetString();
+                    }
+
+                    if (data.ValueKind == JsonValueKind.Array
+                        && data.GetArrayLength() > 0
+                        && data[0].TryGetProperty("id", out var firstId))
+                    {
+                        return firstId.GetString();
+                    }
+                }
+            }
+            catch
+            {
+                return null;
+            }
+
+            return null;
+        }
+    }
+}

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -17,7 +17,8 @@ import {
 
 import { API_BASE_URL } from './src/config/api';
 import { AuthProvider, useAuth } from './src/context/AuthContext';
-import { pollsApi, usersApi, votesApi } from './src/lib/api';
+import { notificationsApi, pollsApi, usersApi, votesApi } from './src/lib/api';
+import { getExpoPushToken } from './src/lib/pushNotifications';
 import { hasCompletedOnboarding, markOnboardingComplete } from './src/lib/session';
 import type { AuthUser } from './src/types/auth';
 import type { ApiPoll, ApiPollOption, VoteReward } from './src/types/poll';
@@ -440,6 +441,8 @@ function OnboardingPoint({ copy, title }: { copy: string; title: string }) {
 function SignedInHome() {
   const { applyVoteReward, signOut, user } = useAuth();
   const [activeTab, setActiveTab] = useState<SignedInTab>('home');
+  const [pushToken, setPushToken] = useState<string | null>(null);
+  const [pushNotice, setPushNotice] = useState<string | null>(null);
   const [leaderboard, setLeaderboard] = useState<AuthUser[]>([]);
   const [isLeaderboardLoading, setIsLeaderboardLoading] = useState(false);
   const [leaderboardError, setLeaderboardError] = useState<string | null>(null);
@@ -487,6 +490,34 @@ function SignedInHome() {
   }, [loadPolls]);
 
   useEffect(() => {
+    let isMounted = true;
+
+    async function registerForPush() {
+      try {
+        const token = await getExpoPushToken();
+        if (!token) {
+          if (isMounted) setPushNotice('Enable notifications to get streak and daily poll reminders.');
+          return;
+        }
+
+        await notificationsApi.registerDeviceToken(token, Platform.OS);
+        if (isMounted) {
+          setPushToken(token);
+          setPushNotice(null);
+        }
+      } catch {
+        if (isMounted) setPushNotice('Push reminders could not be enabled on this device.');
+      }
+    }
+
+    registerForPush();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
     if (activeTab === 'leaderboard' && leaderboard.length === 0) {
       loadLeaderboard();
     }
@@ -510,6 +541,14 @@ function SignedInHome() {
     }
   }
 
+  async function logout() {
+    if (pushToken) {
+      await notificationsApi.disableDeviceToken(pushToken).catch(() => undefined);
+    }
+
+    await signOut();
+  }
+
   if (!user) return null;
 
   const level = getLevel(user.xp ?? 0);
@@ -522,7 +561,7 @@ function SignedInHome() {
           <Text style={styles.eyebrow}>Pollify</Text>
           <Text style={styles.feedTitle}>Hi, {user.displayName}</Text>
         </View>
-        <Pressable onPress={signOut} style={styles.logoutButton}>
+        <Pressable onPress={logout} style={styles.logoutButton}>
           <Text style={styles.logoutButtonText}>Logout</Text>
         </Pressable>
       </View>
@@ -555,6 +594,12 @@ function SignedInHome() {
               ? `Daily streak is now ${latestReward.streak}.`
               : `Streak stays at ${latestReward.streak}.`}
           </Text>
+        </View>
+      )}
+
+      {pushNotice && (
+        <View style={styles.pushNotice}>
+          <Text style={styles.pushNoticeText}>{pushNotice}</Text>
         </View>
       )}
 
@@ -1081,6 +1126,21 @@ const styles = StyleSheet.create({
     color: '#E7EFF2',
     fontSize: 14,
     fontWeight: '700',
+    letterSpacing: 0,
+    lineHeight: 20,
+  },
+  pushNotice: {
+    backgroundColor: '#FFF6D8',
+    borderColor: '#F4D35E',
+    borderRadius: 8,
+    borderWidth: 1,
+    marginBottom: 12,
+    padding: 12,
+  },
+  pushNoticeText: {
+    color: '#5C4A12',
+    fontSize: 14,
+    fontWeight: '800',
     letterSpacing: 0,
     lineHeight: 20,
   },

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -10,6 +10,8 @@ The app uses the existing Pollify backend auth endpoints:
 
 JWT sessions are stored with Expo SecureStore on device.
 
+The app registers an Expo push token after sign-in so retention notifications can reach Android users. Logout disables the current device token through the backend before clearing the local session.
+
 Signed-in users can switch between mobile gamification surfaces:
 
 - Home: current XP, streak, level progress, and native trending poll feed.
@@ -30,6 +32,13 @@ The feed is backed by:
 - `POST /api/votes`
 
 Vote responses update the selected poll, XP, streak, and total vote count in the mobile UI.
+
+Push reminders use:
+
+- `POST /api/notifications/device-tokens`
+- `DELETE /api/notifications/device-tokens?token=...`
+
+Expo push does not require a committed secret for this MVP path. Production EAS builds should still define a stable Expo project and keep any future service credentials in EAS environment settings, not in the repo.
 
 ## Requirements
 

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -20,7 +20,9 @@
         "backgroundImage": "./assets/android-icon-background.png",
         "monochromeImage": "./assets/android-icon-monochrome.png"
       },
-      "permissions": [],
+      "permissions": [
+        "POST_NOTIFICATIONS"
+      ],
       "predictiveBackGestureEnabled": false
     },
     "web": {
@@ -32,7 +34,8 @@
       "backgroundColor": "#F7F5EF"
     },
     "plugins": [
-      "expo-secure-store"
+      "expo-secure-store",
+      "expo-notifications"
     ],
     "extra": {
       "releaseChannel": "production"

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "expo": "~56.0.4",
+        "expo-notifications": "^56.0.15",
         "expo-secure-store": "~56.0.4",
         "expo-status-bar": "~56.0.4",
         "react": "19.2.3",
@@ -2052,6 +2053,12 @@
         "@babel/plugin-syntax-flow": "^7.12.1"
       }
     },
+    "node_modules/badgin": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/badgin/-/badgin-1.2.3.tgz",
+      "integrity": "sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==",
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -2711,6 +2718,28 @@
         }
       }
     },
+    "node_modules/expo-application": {
+      "version": "56.0.3",
+      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-56.0.3.tgz",
+      "integrity": "sha512-DdGGPlMuM6cSTeKhbvh6OeLr2O/+EI5BHKYrD+Do8sJPYgLwzGrgESELfyjJCpEhFzT+TgKIdmLmWXhNUQnHiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-constants": {
+      "version": "56.0.16",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-56.0.16.tgz",
+      "integrity": "sha512-6tsiN+gmTUPp/atyA+uY9Tg8VOdXdmb4s/3TVGolfn6A/oCAraw1pcPZX5XllyD+xUguxB6eBSFAT8494hZVMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/env": "~2.3.0"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "56.0.12",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-56.0.12.tgz",
@@ -2753,6 +2782,24 @@
       "integrity": "sha512-iBAj4Xeh/8HT201VVxFlmf+VBfmtQV1ZUoJdLQQENm0+j9gnD2QswZLJyNo3CmNNXl46esJeLR5lpGpYZts/zA==",
       "license": "MIT",
       "peerDependencies": {
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-notifications": {
+      "version": "56.0.15",
+      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-56.0.15.tgz",
+      "integrity": "sha512-F+OasAePiVnHaPNKI9JAYV8fg8bdBwo7Mh9R3ydBp8S21fRQyxKOSgJvj8fX/HoPFFIC6V2B+y1LJbG5Ovh/Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.10.1",
+        "abort-controller": "^3.0.0",
+        "badgin": "^1.1.5",
+        "expo-application": "~56.0.3",
+        "expo-constants": "~56.0.16"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
         "react-native": "*"
       }
     },
@@ -3075,19 +3122,6 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/expo/node_modules/expo-constants": {
-      "version": "56.0.15",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-56.0.15.tgz",
-      "integrity": "sha512-7187sd55swLX+CM0noAV5LreEgkUaDG/zEXy9quonfzKpJxy8zJAszp9S++xOx/FcqBVEEEcQhE8tKTujwL8fg==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/env": "~2.3.0"
-      },
-      "peerDependencies": {
-        "expo": "*",
         "react-native": "*"
       }
     },

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -4,6 +4,7 @@
   "main": "index.ts",
   "dependencies": {
     "expo": "~56.0.4",
+    "expo-notifications": "^56.0.15",
     "expo-secure-store": "~56.0.4",
     "expo-status-bar": "~56.0.4",
     "react": "19.2.3",

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -68,6 +68,19 @@ export const usersApi = {
     }),
 };
 
+export const notificationsApi = {
+  registerDeviceToken: (token: string, platform: 'android' | 'ios' | string) =>
+    apiRequest<{ success: boolean }>('/api/notifications/device-tokens', {
+      method: 'POST',
+      body: JSON.stringify({ token, platform }),
+    }),
+  disableDeviceToken: (token: string) =>
+    apiRequest<{ success: boolean }>(
+      `/api/notifications/device-tokens?token=${encodeURIComponent(token)}`,
+      { method: 'DELETE' },
+    ),
+};
+
 export const pollsApi = {
   getTrending: (count = 20) => apiRequest<ApiPoll[]>(`/api/polls/trending?count=${count}`),
 };

--- a/apps/mobile/src/lib/pushNotifications.ts
+++ b/apps/mobile/src/lib/pushNotifications.ts
@@ -1,0 +1,32 @@
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldPlaySound: true,
+    shouldSetBadge: false,
+    shouldShowBanner: true,
+    shouldShowList: true,
+  }),
+});
+
+export async function getExpoPushToken() {
+  if (Platform.OS === 'android') {
+    await Notifications.setNotificationChannelAsync('pollify-retention', {
+      name: 'Pollify reminders',
+      importance: Notifications.AndroidImportance.DEFAULT,
+      vibrationPattern: [0, 250, 250, 250],
+      lightColor: '#B0413E',
+    });
+  }
+
+  const existing = await Notifications.getPermissionsAsync();
+  const finalStatus = existing.granted
+    ? existing.status
+    : (await Notifications.requestPermissionsAsync()).status;
+
+  if (finalStatus !== 'granted') return null;
+
+  const token = await Notifications.getExpoPushTokenAsync();
+  return token.data;
+}


### PR DESCRIPTION
## Summary
- Add backend storage for mobile Expo device tokens and push delivery attempts
- Add authenticated device-token register/disable endpoints under notifications
- Add an Expo push sender and wire the retention notification job to dispatch pending push payloads with type, notification, poll, and path context
- Register Expo push tokens from the mobile app after sign-in and disable the current token on logout
- Configure Expo notifications for Android and document the mobile push endpoints/setup

## Verification
- \dotnet build Backend\\BackendAPI\\BackendAPI.csproj\ (passes with existing nullable warning in \AuthRepository.cs\)
- \
pm run typecheck\ from \pps/mobile\
- \
px expo config --type public\ from \pps/mobile\ (passes; existing Node.js v20.18.0 warning remains)
- \git diff --check\

Notes:
- \
pm install expo-notifications\ reports the existing Node engine warning and 10 moderate audit findings; no audit fix was applied to avoid unrelated dependency churn.

Closes #97