### PR TITLE
Add Android release smoke-test checklist

### DIFF
--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -1,0 +1,1 @@
+EXPO_PUBLIC_API_URL=http://10.0.2.2:5177

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -70,6 +70,8 @@ $env:EXPO_PUBLIC_API_URL = "http://192.168.1.10:5177"
 npm run android
 ```
 
+You can also copy `.env.example` for a local default API URL.
+
 The web app remains in `Frontend` and can continue to use `NEXT_PUBLIC_API_URL`.
 
 ## Auth Notes
@@ -82,9 +84,9 @@ Android release builds use EAS profiles in `eas.json`.
 
 ```powershell
 cd apps/mobile
-npm run typecheck
+npm run verify:android:release
 npm run build:android:preview
 npm run build:android:production
 ```
 
-See `docs/android-release.md` for Play Store checklist, privacy policy requirements, credential handling, and submit instructions.
+See `docs/android-release.md` for Play Store checklist, privacy policy requirements, credential handling, and submit instructions. Use `docs/android-smoke-test.md` before uploading an internal testing build.

--- a/apps/mobile/docs/android-release.md
+++ b/apps/mobile/docs/android-release.md
@@ -16,14 +16,22 @@ Do not commit credentials or private keys. Store these in EAS or local developer
 - Google Play service account JSON: configure through `eas submit:configure` or EAS secrets, never as a committed file.
 - Android signing key: let EAS manage credentials, or store keystores outside the repo.
 
-Before production builds, replace the placeholder API URL in `eas.json` with the deployed backend URL or set it through EAS environment variables.
+Before production builds, replace the placeholder API URL in `eas.json` with the deployed backend URL or set it through EAS environment variables. For local development, copy `.env.example` and set the URL for your emulator or physical device.
+
+## Prerequisites
+
+- Node.js 20.19.4 or newer.
+- Expo/EAS CLI access through `npx eas`.
+- Android Studio for emulator testing, or a physical Android device.
+- A reachable backend URL for the target device.
+- A Play Console app and internal testing track before production submit.
 
 ## Release Commands
 
 ```powershell
 cd apps/mobile
 npm install
-npm run typecheck
+npm run verify:android:release
 npx eas login
 npx eas build:configure
 npm run build:android:preview
@@ -64,5 +72,6 @@ The privacy policy must cover:
 - Confirm `android.versionCode` increments for each Play Store upload.
 - Confirm `expo.android.permissions` stays minimal.
 - Confirm no `.env`, service account JSON, keystore, or secret file is staged.
-- Run `npm run typecheck`.
+- Run `npm run verify:android:release`.
 - Build preview APK first, install on Android, then build production AAB.
+- Complete the real-device checklist in `docs/android-smoke-test.md`.

--- a/apps/mobile/docs/android-smoke-test.md
+++ b/apps/mobile/docs/android-smoke-test.md
@@ -1,0 +1,99 @@
+# Android Smoke Test Checklist
+
+Use this checklist before every Play Store internal testing upload. It is designed for a preview APK first, then the production AAB.
+
+## Local Preflight
+
+```powershell
+cd apps/mobile
+npm install
+npm run verify:android:release
+```
+
+Expected result:
+
+- TypeScript passes with no errors.
+- `npx expo config --type public` prints `android.package` as `com.pollify.app`.
+- Android permissions stay limited to the permissions intentionally configured in `app.json`.
+- The Expo config output uses the expected `EXPO_PUBLIC_API_URL` for the target environment.
+
+## Backend URL Setup
+
+The mobile app reads `EXPO_PUBLIC_API_URL` at build/start time.
+
+Android emulator:
+
+```powershell
+$env:EXPO_PUBLIC_API_URL = "http://10.0.2.2:5177"
+npm run android
+```
+
+Physical Android device:
+
+```powershell
+$env:EXPO_PUBLIC_API_URL = "http://<your-lan-ip>:5177"
+npm run android
+```
+
+Preview/production EAS builds:
+
+- Replace the placeholder in `eas.json`, or preferably set `EXPO_PUBLIC_API_URL` in EAS environment settings.
+- The API URL is public in the app bundle, so never put secrets in this variable.
+- The backend must be reachable from the device, not just from the developer machine.
+
+## Preview APK Build
+
+```powershell
+cd apps/mobile
+npx eas login
+npm run build:android:preview
+```
+
+Install the generated APK on a real Android phone from the EAS build page.
+
+## Real-Device Smoke Test
+
+Record the device model, Android version, build profile, API URL, and test account used.
+
+- App launches to login/register without a crash.
+- Register a new account.
+- Log out and log back in with the same account.
+- First-run onboarding appears for a new user.
+- Category preference selection completes and the app opens the signed-in home.
+- Feed loads trending polls from the configured backend.
+- Pull-to-refresh reloads the feed.
+- Vote on a poll and confirm result bars appear.
+- XP, streak, and total vote counters update after voting.
+- Duplicate vote or expired poll errors show a readable message.
+- Leaderboard loads real backend users.
+- Profile shows display name, username, XP, streak, votes, polls created, and joined date.
+- Push notification permission prompt appears after sign-in on Android 13+.
+- Logout clears the session and disables the current push token.
+- Relaunching the app restores the signed-in session when not logged out.
+- Relaunching after logout stays on the auth screen.
+
+## Production AAB Check
+
+Only run this after the preview APK smoke test passes.
+
+```powershell
+cd apps/mobile
+npm run build:android:production
+```
+
+Before uploading to Play Console:
+
+- `android.versionCode` increments from the previous Play upload.
+- App package remains `com.pollify.app`.
+- No `.env`, service account JSON, keystore, or Play credential file is staged.
+- Privacy policy URL is live.
+- Store listing screenshots reflect the current mobile UI.
+- Play Console internal testing track has a tester group configured.
+
+## Troubleshooting
+
+- Emulator cannot reach backend: use `http://10.0.2.2:<port>` instead of `localhost`.
+- Physical device cannot reach backend: use the machine LAN IP and allow the backend port through firewall.
+- HTTPS/dev certificate errors: use a reachable HTTPS deployment for EAS builds, or use HTTP only for local development.
+- Push token registration fails: confirm the user is signed in, backend URL is reachable, and the `US97_Expo_Push_Notifications.sql` migration has run.
+- EAS build asks for credentials: let EAS manage Android credentials unless there is a deliberate release-key migration plan.

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -20,6 +20,8 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "typecheck": "tsc --noEmit",
+    "verify:android:config": "npx expo config --type public",
+    "verify:android:release": "npm run typecheck && npm run verify:android:config",
     "build:android:preview": "npx eas build --platform android --profile preview",
     "build:android:production": "npx eas build --platform android --profile production",
     "submit:android:production": "npx eas submit --platform android --profile production"


### PR DESCRIPTION
## Summary
- Add a repeatable Android release preflight script for typecheck plus Expo public config validation
- Add a real-device Android smoke-test checklist covering auth, onboarding, feed, voting, rewards, leaderboard, profile, push permission, logout, and session restore
- Document backend URL setup for emulator, physical devices, and EAS builds
- Add a non-secret mobile .env.example for local API configuration
- Update Android release docs to point at the checklist and preflight command

## Verification
- \
pm run verify:android:release\ from \pps/mobile\ (passes; Expo still warns local Node.js v20.18.0 is below required/recommended >=20.19.4)
- \git diff --check\

Notes:
- I did not run a cloud EAS preview build because that requires logged-in EAS project/build credentials and may consume remote build resources. The new checklist documents that required step for release QA.

Closes #98